### PR TITLE
Fix broken SRF conditional that most likely caused Chronos dongle to …

### DIFF
--- a/firmware/include/global.h
+++ b/firmware/include/global.h
@@ -74,7 +74,7 @@ extern __xdata u32 clock;
 // USB activities
 #ifdef CHRONOSDONGLE
     #define USB_ENABLE_PIN              P1_1
-##elif defined SRFSTICK
+#elif defined SRFSTICK
     #define USB_ENABLE_PIN              P2_0
 #else
     #define USB_ENABLE_PIN              P1_0


### PR DESCRIPTION
…break

Fix the cause of the following build warning (when calling make with no arguments):
>In file included from chipcon_usb.c:1:
>include/global.h:78:1: warning: "USB_ENABLE_PIN" redefined
>include/global.h:76:1: error: this is the location of the previous definition`

Given the location of the error, it is possible that the Chronos dongle would have the incorrect definition of `USB_ENABLE_PIN`