### PR TITLE
Remove cc1111client.py and update references

### DIFF
--- a/.vimloader
+++ b/.vimloader
@@ -16,7 +16,6 @@
 :tabnew ./rfcat_server
 :tabnew ./rflib/__init__.py
 :tabnew ./rflib/chipcon_nic.py
-:tabnew ./rflib/cc1111client.py
 :tabnew ./rflib/cc111Xhparser.py
 :tabnew ./rflib/chipcondefs.py
 :tabnext

--- a/firmware/include/cc1111rf.h
+++ b/firmware/include/cc1111rf.h
@@ -9,7 +9,7 @@
 //                  switch buffers mid-stream
 
 #define DMA_CFG_SIZE 8
-// BUFFER size must match RF_MAX_RX_BLOCK defined in rflib/cc1111client.py 
+// BUFFER size must match RF_MAX_RX_BLOCK defined in rflib/chipcon_nic.py
 #define BUFFER_SIZE 512
 #define BUFFER_AMOUNT 2
 

--- a/firmware/include/chipcon_usb.h
+++ b/firmware/include/chipcon_usb.h
@@ -8,7 +8,7 @@
 #define     EP5_MAX_PACKET_SIZE     64
 #define     EP5OUT_MAX_PACKET_SIZE  64
 #define     EP5IN_MAX_PACKET_SIZE   64
-// EP5OUT_BUFFER_SIZE must match rflib/cc1111client.py definition
+// EP5OUT_BUFFER_SIZE must match rflib/chipcon_usb.py definition
 #define     EP5OUT_BUFFER_SIZE      516 // data buffer size + 4
 
 #define     EP_STATE_IDLE      0


### PR DESCRIPTION
Remove empty file `rflib/cc1111client.py` and update any references to this file, because the `EP5OUT_BUFFER_SIZE` and `RF_MAX_RX_BLOCK` variables aren't defined in `rflib/cc1111client.py`.