### PR TITLE
fix build incompatibility with predef NOP macro

### DIFF
--- a/firmware/include/cc2531.h
+++ b/firmware/include/cc2531.h
@@ -46,7 +46,12 @@ SFRX(USBF5,     0x622A);        // Endpoint 5 FIFO
 // USB activities
 #define USB_ENABLE_PIN              P1_0
 //#define USB_ENABLE_PIN              P1_1
+
+// NOP macro which may be defined elsewhere
+#ifndef NOP
 #define NOP()                       __asm; nop; __endasm;
+#endif
+
 #define USB_DISABLE()               SLEEP &= ~SLEEP_USB_EN;
 #define USB_ENABLE()                SLEEP |= SLEEP_USB_EN;
 #define USB_RESET()                 USB_DISABLE(); NOP(); USB_ENABLE();

--- a/firmware/include/global.h
+++ b/firmware/include/global.h
@@ -81,7 +81,11 @@ extern __xdata u8 ledMode;
 #else
     #define USB_ENABLE_PIN              P1_0
 #endif
+
+// NOP macro which may be defined elsewhere
+#ifndef NOP
 #define NOP()                       __asm; nop; __endasm;
+#endif
 
 // USB data buffer
 #define BUFFER_AVAILABLE		0x00


### PR DESCRIPTION
This resolves #29, by wrapping the define in a conditional.