### PR TITLE
Enable firmware builds when Python 3 is default.

### DIFF
--- a/firmware/bootloader_serial.py
+++ b/firmware/bootloader_serial.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import sys
 from rflib.intelhex import IntelHex

--- a/firmware/bootloader_serial.py
+++ b/firmware/bootloader_serial.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys
 from rflib.intelhex import IntelHex

--- a/firmware/new_serial.py
+++ b/firmware/new_serial.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 import sys
 
 sn_header = """// Serial number

--- a/firmware/new_serial.py
+++ b/firmware/new_serial.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from __future__ import print_function
 import sys
 
 sn_header = """// Serial number
@@ -7,13 +8,18 @@ sn_header = """// Serial number
 """
 
 try:
-    ser = int(file(".serial", 'rb').read(), 16) #+ 1
+    f = open('.serial', 'r')
+    ser = int(f.read(), 16) #+ 1
+    f.close()
 except IOError:
     ser = 0
 
-print >>sys.stderr,("[--- new serial number: %.4x ---]" % ser)
+print("[--- new serial number: %.4x ---]" % ser, file=sys.stderr)
 
-file(".serial", 'wb').write("%.4x" % ser)
+f = open('.serial', 'w')
+f.write("%.4x" % ser)
+f.close()
+
 sertxt = "%.4x" % ser
 
 for c in sertxt:


### PR DESCRIPTION
Updates `new_serial.py` to be compatible with both 2.7 and 3, and updates `bootloader_serial.py` to explicitly call python2 until the rest of rflib is python3 compatible.