### PR TITLE
replace hg revision script with a git equiv

### DIFF
--- a/revision.sh
+++ b/revision.sh
@@ -1,7 +1,7 @@
 
-hg parent >/dev/null 2>&1
+git rev-list HEAD >/dev/null 2>&1
 if [ $? -eq 0 ]; then
-    hg parent --template '{rev}' | tee .revision
+    git rev-list HEAD --count | tee .revision
 else
     [ -e .revision ] && cat .revision || echo '65535'
 fi


### PR DESCRIPTION
this updates revision.sh for git. it behaves similarly to the old hg script, but it may be desirable to update it to use git describe later