### PR TITLE
Drop support for Python 2.6 and older

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The goals of the project are to reduce the time for security researchers to crea
 
 ## REQUIREMENTS
 
-RfCat currently requires Python 2.x.  the only suspected incompatabilities with Python 3.x are minimal, mostly print("stuff") versus print "stuff" and other str/bytes issues.
+RfCat currently requires Python 2.7.  the only suspected incompatabilities with Python 3.x are minimal, mostly print("stuff") versus print "stuff" and other str/bytes issues.
 
 ### Other requirements
 

--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,7 @@ reverse-engineering of hardware, and to satiate my rf lust.
 REQUIREMENTS
 ------------
 
-RfCat currently requires Python 2.x. the only suspected
+RfCat currently requires Python 2.7. the only suspected
 incompatabilities with Python 3.x are minimal, mostly print(“stuff”)
 versus print “stuff” and other str/bytes issues.
 

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,6 @@ setup  (name             = 'rfcat',
                             # Specify the Python versions you support here. In particular, ensure
                             # that you indicate whether you support Python 2, Python 3 or both.
                             'Programming Language :: Python :: 2',
-                            'Programming Language :: Python :: 2.6',
                             'Programming Language :: Python :: 2.7',
                             # 'Programming Language :: Python :: 3',
                             # 'Programming Language :: Python :: 3.2',
@@ -70,5 +69,5 @@ setup  (name             = 'rfcat',
                             'libusb>=1.0.21b2',
                             'PySide2==5.12.0'
                            ],
-        python_requires  = '>2.0,<3.0.0'
+        python_requires  = '>=2.7,<3.0.0'
         )


### PR DESCRIPTION
Python 2.6 is no longer freely supported! While we can make an effort into making the Python 2.6 work with Python 3, it is **much** easier if we only have to work with Python 2.7.

**Note:** this allows #15 to be fixed with minimal effort while keeping compatibility with Python 2.