### PR TITLE
Intial Porting of Python 2 Code to Python 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ If you have configured your system to allow non-root use:
     * d.debug()
     * d.RFxmit('blahblahblah')
     * d.RFrecv()
-    * print d.reprRadioConfig()
+    * print(d.reprRadioConfig())
     * d.setMdmDRate(19200)      # this sets the modem baud rate (or DataRate)
     * d.setPktPQT(0)            # this sets the preamble quality threshold to 0
     * d.setEnableMdmFEC(True)   # enables the convolutional Forward Error Correction built into the radio

--- a/README.rst
+++ b/README.rst
@@ -345,7 +345,7 @@ If you have configured your system to allow non-root use:
    -  d.debug()
    -  d.RFxmit(‘blahblahblah’)
    -  d.RFrecv()
-   -  print d.reprRadioConfig()
+   -  print(d.reprRadioConfig())
    -  d.setMdmDRate(19200) # this sets the modem baud rate (or DataRate)
    -  d.setPktPQT(0) # this sets the preamble quality threshold to 0
    -  d.setEnableMdmFEC(True) # enables the convolutional Forward Error

--- a/firmware/bootloader_serial.py
+++ b/firmware/bootloader_serial.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 from __future__ import print_function
 

--- a/firmware/bootloader_serial.py
+++ b/firmware/bootloader_serial.py
@@ -1,4 +1,6 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
+
+from __future__ import print_function
 
 import sys
 from rflib.intelhex import IntelHex
@@ -13,7 +15,7 @@ else:
     except IOError:
         ser = 0
 
-print >>sys.stderr,("[--- new serial number: %.4x ---]" % ser)
+print(("[--- new serial number: %.4x ---]" % ser), file=sys.stderr)
 
 if WRITEBACK:
     file(".serial", 'wb').write("%.13x" % ser)

--- a/rfcat
+++ b/rfcat
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
+
 import sys
 import readline
 import rlcompleter
@@ -21,7 +23,7 @@ you interact with the rfcat dongle:
     >>> d.makePktFLEN(250)
     >>> d.RFxmit("HALLO")
     >>> d.RFrecv()
-    >>> print d.reprRadioConfig()
+    >>> print(d.reprRadioConfig())
 
 """
 
@@ -42,10 +44,10 @@ if __name__ == "__main__":
 
     if ifo.bootloader:
         if not ifo.force:
-            print "Protecting you from yourself.  If you want to trigger Bootloader mode (you will then *have* to flash a new RfCat image on it) use the --force argument as well"
+            print("Protecting you from yourself.  If you want to trigger Bootloader mode (you will then *have* to flash a new RfCat image on it) use the --force argument as well")
             exit(-1)
 
-        print "Entering RfCat Bootloader mode, ready for new image..."
+        print("Entering RfCat Bootloader mode, ready for new image...")
         RfCat(ifo.index).bootloader()
         exit(0)
 

--- a/rfcat_msfrelay
+++ b/rfcat_msfrelay
@@ -1,6 +1,8 @@
 #!/usr/bin/python
 # Modified rfcat_server to support Metasploit HWBridge
 
+from __future__ import print_function
+
 import re
 import os
 import sys

--- a/rfcat_server
+++ b/rfcat_server
@@ -1,5 +1,7 @@
 #!/usr/bin/python
 
+from __future__ import print_function
+
 import re
 import os
 import sys
@@ -112,16 +114,16 @@ class CC1111NIC_Server(cmd.Cmd):
                 while True:
                     # implement pipe between the usb RF NIC and the TCP socket
                     try:
-                        print >>sys.stderr,("Listening for NIC connection on port %d" % self._nicport)
+                        print(("Listening for NIC connection on port %d" % self._nicport), file=sys.stderr)
                         self._nicsock = s.accept()
                         rs, addr = self._nicsock
                         rs.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-                        print "== received DATA connection from %s:%d ==" % (addr)
+                        print("== received DATA connection from %s:%d ==" % (addr))
 
                         # handing off the socket for rf_redirection, socket-style
                         self.nic.rf_redirection( (rs,) )
 
-                        print >>sys.stderr,("NIC connection on port %d terminated" % self._nicport)
+                        print(("NIC connection on port %d terminated" % self._nicport), file=sys.stderr)
 
                     except KeyboardInterrupt:
                         self._go = False
@@ -152,7 +154,7 @@ class CC1111NIC_Server(cmd.Cmd):
                 self._cfgsock = s.accept()
                 rs,addr = self._cfgsock
                 rs.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-                print "== received CONFIG connection from %s:%d ==" % (addr)
+                print("== received CONFIG connection from %s:%d ==" % (addr))
 
                 self.stdin = FileSocket(rs)
                 self.stdout = self.stdin
@@ -173,7 +175,7 @@ class CC1111NIC_Server(cmd.Cmd):
         #ok so just kill the connection :)
 
     def Print(self, info):
-        print >>self.stdout,(info)
+        print((info), file=self.stdout)
 
 
     def do_stop(self, line):
@@ -674,7 +676,7 @@ class CC1111NIC_Server(cmd.Cmd):
         (be very cautious!  the firmware expects certain things like return-to-RX, and no RX-timeout, etc..)
         '''
         self.nic.setModeIDLE()
-        print "loading config from bytes: %s" % repr(line)
+        print("loading config from bytes: %s" % repr(line))
         self.setRadioConfig(line)
         self.nic.setModeRX()
 
@@ -698,7 +700,7 @@ class CC1111NIC_Server(cmd.Cmd):
         '''
         config = file(line, "rb").read()
         self.nic.setModeIDLE()
-        print "loading config from bytes: %s" % repr(config)
+        print("loading config from bytes: %s" % repr(config))
         self.setRadioConfig(config)
         self.nic.setModeRX()
 

--- a/rflib/__init__.py
+++ b/rflib/__init__.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env ipython -i --no-banner
-from chipcon_nic import *
+
+from __future__ import print_function
+from __future__ import absolute_import
+
+from .chipcon_nic import *
 import rflib.bits as rfbits
 
 RFCAT_START_SPECAN  = 0x40
@@ -12,7 +16,7 @@ class RfCat(FHSSNIC):
         try:
             for x in xrange(maxnum):
                 y, t = self.RFrecv(timeoutms)
-                print "(%5.3f) %s:  %s" % (t, msg, y.encode('hex'))
+                print("(%5.3f) %s:  %s" % (t, msg, y.encode('hex')))
         except ChipconUsbTimeoutException:
             pass
 
@@ -23,18 +27,18 @@ class RfCat(FHSSNIC):
         self.RFdump("Clearing")
         self.lowball(lowball)
         self.setMdmDRate(drate)
-        print "Scanning range:  "
+        print("Scanning range:  ")
         while not keystop():
             try:
-                print "(press Enter to quit)"
+                print("(press Enter to quit)")
                 for freq in xrange(int(basefreq), int(basefreq+(inc*count)), int(inc)):
-                    print "Scanning for frequency %d..." % freq
+                    print("Scanning for frequency %d..." % freq)
                     self.setFreq(freq)
                     self.RFdump(timeoutms=delaysec*1000)
                     if keystop():
                         break
             except KeyboardInterrupt:
-                print "Please press <enter> to stop"
+                print("Please press <enter> to stop")
 
         sys.stdin.read(1)
         self.lowballRestore()
@@ -209,10 +213,10 @@ def interactive(idx=0, DongleClass=RfCat, intro=''):
     try:
         import IPython.Shell
         ipsh = IPython.Shell.IPShell(argv=[''], user_ns=lcls, user_global_ns=gbls)
-        print intro
+        print(intro)
         ipsh.mainloop(intro)
 
-    except ImportError, e:
+    except ImportError as e:
         try:
             from IPython.terminal.interactiveshell import TerminalInteractiveShell
             ipsh = TerminalInteractiveShell()
@@ -221,7 +225,7 @@ def interactive(idx=0, DongleClass=RfCat, intro=''):
             ipsh.autocall = 2       # don't require parenthesis around *everything*.  be smart!
             ipsh.show_banner(intro)
             ipsh.mainloop()
-        except ImportError, e:
+        except ImportError as e:
             try:
                 from IPython.frontend.terminal.interactiveshell import TerminalInteractiveShell
                 ipsh = TerminalInteractiveShell()
@@ -229,8 +233,8 @@ def interactive(idx=0, DongleClass=RfCat, intro=''):
                 ipsh.user_global_ns.update(lcls)
                 ipsh.autocall = 2       # don't require parenthesis around *everything*.  be smart!
                 ipsh.mainloop(intro)
-            except ImportError, e:
-                print e
+            except ImportError as e:
+                print(e)
                 shell = code.InteractiveConsole(gbls)
                 shell.interact(intro)
 

--- a/rflib/bits.py
+++ b/rflib/bits.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import struct
 
 fmtsLSB = [None, "B", "<H", "<I", "<I", "<Q", "<Q", "<Q", "<Q"]
@@ -230,7 +232,7 @@ def findSyncWordDoubled(byts):
             for frontbits in xrange(16, 40, 2):    #FIXME: if this doesn't work, try 16, then 18+frontbits
                 dwb1 = (bits1 >> (frontbits)) & 3
                 dwb2 = (bits2 >> (frontbits)) & 3
-                print "\tfrontbits: %d \t\t dwb1: %s dwb2: %s" % (frontbits, bin(bits1 >> (frontbits)), bin(bits2 >> (frontbits)))
+                print("\tfrontbits: %d \t\t dwb1: %s dwb2: %s" % (frontbits, bin(bits1 >> (frontbits)), bin(bits2 >> (frontbits))))
                 if dwb2 != dwb1:
                     break
 
@@ -238,17 +240,17 @@ def findSyncWordDoubled(byts):
             for tailbits in xrange(16, -1, -2):
                 dwb1 = (bits1 >> (tailbits)) & 3
                 dwb2 = (bits2 >> (tailbits)) & 3
-                print "\ttailbits: %d\t\t dwb1: %s dwb2: %s" % (tailbits, bin(bits1 >> (tailbits)), bin(bits2 >> (tailbits)))
+                print("\ttailbits: %d\t\t dwb1: %s dwb2: %s" % (tailbits, bin(bits1 >> (tailbits)), bin(bits2 >> (tailbits))))
                 if dwb2 != dwb1:
                     tailbits += 2
                     break
 
             # now, if we have a double syncword, iinm, tailbits + frontbits >= 16
-            print "frontbits: %d\t\t tailbits: %d, bits: %s " % (frontbits, tailbits, bin((bits2>>tailbits & 0xffffffff)))
+            print("frontbits: %d\t\t tailbits: %d, bits: %s " % (frontbits, tailbits, bin((bits2>>tailbits & 0xffffffff))))
             if (frontbits + tailbits >= 16):
                 tbits = bits2 >> (tailbits&0xffff)
                 tbits &= (0xffffffff)
-                print "tbits: %x" % tbits
+                print("tbits: %x" % tbits)
 
                 poss = tbits&0xffffffff
                 if poss not in possDwords:
@@ -311,8 +313,8 @@ def detectRepeatPatterns(data, size=64, minEntropy=.07):
             if d1 == d2 and d1 > 0:
                 s1 = p1 - size
                 s2 = p2 - size
-                print "s1: %d\t  p1: %d\t  " % (s1, p1)
-                print "s2: %d\t  p2: %d\t  " % (s2, p2)
+                print("s1: %d\t  p1: %d\t  " % (s1, p1))
+                print("s2: %d\t  p2: %d\t  " % (s2, p2))
                 # complete the pattern until the numbers differ or meet
                 while True:
                     p1 += 1
@@ -334,9 +336,9 @@ def detectRepeatPatterns(data, size=64, minEntropy=.07):
 
                 bitSection, ent = bitSectString(data, s1, s1+length)
                 if ent > minEntropy:
-                    print "success:"
-                    print "  * bit idx1: %4d (%4d bits) - '%s' %s" % (s1, length, bin(d1), bitSection.encode("hex"))
-                    print "  * bit idx2: %4d (%4d bits) - '%s'" % (s2, length, bin(d2))
+                    print("success:")
+                    print("  * bit idx1: %4d (%4d bits) - '%s' %s" % (s1, length, bin(d1), bitSection.encode("hex")))
+                    print("  * bit idx2: %4d (%4d bits) - '%s'" % (s2, length, bin(d2)))
             #else:
             #    print "  * idx1: %d - '%s'  * idx2: %d - '%s'" % (p1, d1, p2, d2)
             p2 += 1
@@ -565,12 +567,12 @@ def biphase_mark_coding_encode(data):
 
             last = bit
         if bidx & 1:
-            print "%d - write" % bidx
+            print("%d - write" % bidx)
             out.append(chr(obyte))
         else:
-            print "%d - skip" % bidx
+            print("%d - skip" % bidx)
     if not (bidx & 1):
-        print "%d - write" % bidx
+        print("%d - write" % bidx)
         out.append(chr(obyte))
 
     return ''.join(out)
@@ -637,7 +639,7 @@ def findManchesterData(data, hilo=1):
             pass
 
 def findManchester(data, minbytes=10):
-    print "DEBUG: DATA=" + repr(data)
+    print("DEBUG: DATA=" + repr(data))
     success = []
 
     last = 0

--- a/rflib/cc111Xhparser.py
+++ b/rflib/cc111Xhparser.py
@@ -40,6 +40,9 @@ SFR(DPH0,     0x83); // Data Pointer 0 High Byte
 SFR(DPL1,     0x84); // Data Pointer 1 Low Byte
 SFR(DPH1,     0x85); // Data Pointer 1 High Byte
 """
+
+from __future__ import print_function
+
 import sys
 
 
@@ -86,14 +89,14 @@ def parseLines(lines):
                 continue
             name, value = pieces
             if "(" in name:
-                print >>sys.stderr,("SKIPPING: %s"%(line))
+                print(("SKIPPING: %s"%(line)), file=sys.stderr)
                 continue                # skip adding "function" defines
             defs[name.strip()] = value.strip()
             
         elif (line.startswith("SFR(")):
             endparen = line.find(")")
             if (endparen == -1):
-                print >>sys.stderr,("ERROR: SFR without end parens: '%s'"%(line))
+                print(("ERROR: SFR without end parens: '%s'"%(line)), file=sys.stderr)
                 continue
             line = line[4:endparen].strip()
             name, value = line.split(",", 1)
@@ -101,7 +104,7 @@ def parseLines(lines):
         elif (line.startswith("SFRX(")):
             endparen = line.find(")")
             if (endparen == -1):
-                print >>sys.stderr,("ERROR: SFRX without end parens: '%s'"%(line))
+                print(("ERROR: SFRX without end parens: '%s'"%(line)), file=sys.stderr)
                 continue
             line = line[5:endparen].strip()
             name, value = line.split(",", 1)
@@ -109,7 +112,7 @@ def parseLines(lines):
         elif (line.startswith("SBIT")):
             endparen = line.find(")")
             if (endparen == -1):
-                print >>sys.stderr,("ERROR: SBIT without end parens: '%s'"%(line))
+                print(("ERROR: SBIT without end parens: '%s'"%(line)), file=sys.stderr)
                 continue
             line = line[5:endparen].strip()
             name, val1, val2 = line.split(",", 2)

--- a/rflib/ccrecvdump.py
+++ b/rflib/ccrecvdump.py
@@ -1,5 +1,9 @@
 #!/usr/bin/python
-import sys, serial
+
+from __future__ import print_function
+
+import sys
+import serial
 
 port = "ACM0"
 if len(sys.argv) > 1:
@@ -7,7 +11,7 @@ if len(sys.argv) > 1:
 
 dport = "/dev/tty" + port
 
-print "Opening serial port %s for listening..." % dport
+print("Opening serial port %s for listening..." % dport)
 s=serial.Serial(dport, 115200)
 
 counter = 0

--- a/rflib/ccspecan.py
+++ b/rflib/ccspecan.py
@@ -19,6 +19,8 @@
 # the Free Software Foundation, Inc., 51 Franklin Street,
 # Boston, MA 02110-1301, USA.
 
+from __future__ import print_function
+
 import sys
 import time
 import numpy
@@ -406,22 +408,22 @@ class Window(QtWidgets.QWidget):
             key= chr(event.key()).upper()
             event.accept()
         except:
-            print 'Unknown key pressed: 0x%x' % event.key()
+            print('Unknown key pressed: 0x%x' % event.key())
             event.ignore()
             return
         if key == 'H':
-            print 'Key              Action' 
-            print
-            print ' <LEFT ARROW>        Reduce base frequency by one step'
-            print ' <RIGHT ARROW>       Increase base frequency by one step'
-            print ' <DOWN ARROW>        Reduce frequency step 10%'
-            print ' <UP ARROW>          Increase frequency step 10%'
-            print ' <LEFT MOUSE>        Mark LEFT frequency / signal strength at pointer'
-            print ' <RIGHT MOUSE>       Mark RIGHT frequency / signal strength at pointer'
-            print ' <MIDDLE MOUSE>      Toggle visibility of frequency / signal strength markers'
-            print ' H                   Print this HELP text'
-            print ' M                   Simulate MIDDLE MOUSE click (for those with trackpads)'
-            print ' Q                   Quit'
+            print('Key              Action') 
+            print()
+            print(' <LEFT ARROW>        Reduce base frequency by one step')
+            print(' <RIGHT ARROW>       Increase base frequency by one step')
+            print(' <DOWN ARROW>        Reduce frequency step 10%')
+            print(' <UP ARROW>          Increase frequency step 10%')
+            print(' <LEFT MOUSE>        Mark LEFT frequency / signal strength at pointer')
+            print(' <RIGHT MOUSE>       Mark RIGHT frequency / signal strength at pointer')
+            print(' <MIDDLE MOUSE>      Toggle visibility of frequency / signal strength markers')
+            print(' H                   Print this HELP text')
+            print(' M                   Simulate MIDDLE MOUSE click (for those with trackpads)')
+            print(' Q                   Quit')
             return
         if key == 'M':
             self.render_area._mouse_x = None
@@ -431,10 +433,10 @@ class Window(QtWidgets.QWidget):
             self.render_area._hide_markers = not self.render_area._hide_markers
             return
         if key == 'Q':
-            print 'Quit!'
+            print('Quit!')
             self.close()
             return
-        print 'Unsupported key pressed:', key
+        print('Unsupported key pressed:', key)
 
 if __name__ == '__main__':
     app = QtWidgets.QApplication(sys.argv)

--- a/rflib/chipcon_nic.py
+++ b/rflib/chipcon_nic.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env ipython
+
+from __future__ import print_function
+from __future__ import absolute_import
+
 import re
 import sys
 import usb
@@ -7,8 +11,8 @@ import time
 import struct
 import pickle
 import threading
-#from chipcondefs import *
-from chipcon_usb import *
+#from .chipcondefs import *
+from .chipcon_usb import *
 
 # band limits in Hz
 FREQ_MIN_300  = 281000000
@@ -276,7 +280,7 @@ def loadPkts(filename):
     return pickle.load( file(filename, 'r'))
 
 def printSyncWords(syncworddict):
-    print "SyncWords seen:"
+    print("SyncWords seen:")
 
     tmp = []
     for x,y in syncworddict.items():
@@ -599,7 +603,7 @@ class NICxx11(USBDongle):
             radiocfg = self.radiocfg
 
         if (mod) & ~MDMCFG2_MOD_FORMAT:
-            raise(Exception("Please use constants MOD_FORMAT_* to specify modulation and "))
+            raise Exception
 
         radiocfg.mdmcfg2 &= ~MDMCFG2_MOD_FORMAT
         radiocfg.mdmcfg2 |= (mod)
@@ -658,7 +662,7 @@ class NICxx11(USBDongle):
                     chanspc_m = m
                     break
         if chanspc_e is None or chanspc_m is None:
-            raise(Exception("ChanSpc does not translate into acceptable parameters.  Should you be changing this?"))
+            raise Exception
 
         #chanspc = 1000000.0 * mhz/pow(2,18) * (256 + chanspc_m) * pow(2, chanspc_e)
         #print "chanspc_e: %x   chanspc_m: %x   chanspc: %f hz" % (chanspc_e, chanspc_m, chanspc)
@@ -675,7 +679,7 @@ class NICxx11(USBDongle):
             radiocfg = self.radiocfg
 
         if maxlen > RF_MAX_TX_BLOCK:
-            raise(Exception("Packet too large (%d bytes). Maximum variable length packet is %d bytes." % (maxlen, RF_MAX_TX_BLOCK)))
+            raise Exception
 
         radiocfg.pktctrl0 &= ~PKTCTRL0_LENGTH_CONFIG
         radiocfg.pktctrl0 |= 1
@@ -690,7 +694,7 @@ class NICxx11(USBDongle):
             radiocfg = self.radiocfg
 
         if flen > EP5OUT_BUFFER_SIZE - 4:
-            raise(Exception("Packet too large (%d bytes). Maximum fixed length packet is %d bytes." % (flen, EP5OUT_BUFFER_SIZE - 6)))
+            raise Exception
 
         radiocfg.pktctrl0 &= ~PKTCTRL0_LENGTH_CONFIG
         # if we're sending a large block, pktlen is dealt with by the firmware
@@ -858,7 +862,7 @@ class NICxx11(USBDongle):
         ifBits = int(ifBits + .5)       # rounded evenly
 
         if ifBits >0x1f:
-            raise(Exception("FAIL:  freq_if is too high?  freqbits: %x (must be <0x1f)" % ifBits))
+            raise Exception
         radiocfg.fsctrl1 &= ~(0x1f)
         radiocfg.fsctrl1 |= int(ifBits)
         self.setRFRegister(FSCTRL1, (radiocfg.fsctrl1))
@@ -957,7 +961,7 @@ class NICxx11(USBDongle):
                 chanbw_m = m
                 break
         if chanbw_e is None:
-            raise(Exception("ChanBW does not translate into acceptable parameters.  Should you be changing this?"))
+            raise Exception
 
         bw = 1000.0*mhz / (8.0*(4+chanbw_m) * pow(2,chanbw_e))
         #print "chanbw_e: %x   chanbw_m: %x   chanbw: %f kHz" % (e, m, bw)
@@ -1007,10 +1011,10 @@ class NICxx11(USBDongle):
                 drate_m = m
                 break
         if drate_e is None:
-            raise(Exception("DRate does not translate into acceptable parameters.  Should you be changing this?"))
+            raise Exception
 
         drate = 1000000.0 * mhz * (256+drate_m) * pow(2,drate_e) / pow(2,28)
-        if self._debug: print "drate_e: %x   drate_m: %x   drate: %f Hz" % (drate_e, drate_m, drate)
+        if self._debug: print("drate_e: %x   drate_m: %x   drate: %f Hz" % (drate_e, drate_m, drate))
         
         radiocfg.mdmcfg3 = drate_m
         radiocfg.mdmcfg4 &= ~MDMCFG4_DRATE_E
@@ -1051,7 +1055,7 @@ class NICxx11(USBDongle):
                 dev_m = m
                 break
         if dev_e is None:
-            raise(Exception("Deviation does not translate into acceptable parameters.  Should you be changing this?"))
+            raise Exception
 
         dev = 1000000.0 * mhz * (8+dev_m) * pow(2,dev_e) / pow(2,17)
         #print "dev_e: %x   dev_m: %x   deviatn: %f Hz" % (e, m, dev)
@@ -1380,7 +1384,7 @@ class NICxx11(USBDongle):
     def RFrecv(self, timeout=USB_RX_WAIT, blocksize=None):
         if not blocksize == None:
             if blocksize > EP5OUT_BUFFER_SIZE: 
-                raise(Exception("Blocksize too large. Maximum %d") % EP5OUT_BUFFER_SIZE)
+                raise Exception("Blocksize too large. Maximum %d")
             self.send(APP_NIC, NIC_SET_RECV_LARGE, "%s" % struct.pack("<H",blocksize))
         data = self.recv(APP_NIC, NIC_RECV, timeout)
         # decode, if necessary
@@ -1395,18 +1399,18 @@ class NICxx11(USBDongle):
     def RFlisten(self):
         ''' just sit and dump packets as they come in
         kinda like discover() but without changing any of the communications settings '''
-        print "Entering RFlisten mode...  packets arriving will be displayed on the screen"
-        print "(press Enter to stop)"
+        print("Entering RFlisten mode...  packets arriving will be displayed on the screen")
+        print("(press Enter to stop)")
         while not keystop():
 
             try:
                 y, t = self.RFrecv()
-                print "(%5.3f) Received:  %s  | %s" % (t, y.encode('hex'), makeFriendlyAscii(y))
+                print("(%5.3f) Received:  %s  | %s" % (t, y.encode('hex'), makeFriendlyAscii(y)))
 
             except ChipconUsbTimeoutException:
                 pass
             except KeyboardInterrupt:
-                print "Please press <enter> to stop"
+                print("Please press <enter> to stop")
 
         sys.stdin.read(1)
 
@@ -1414,20 +1418,20 @@ class NICxx11(USBDongle):
         ''' dump packets as they come in, but return a list of packets when you exit capture mode.
         kinda like discover() but without changing any of the communications settings '''
         capture = []
-        print "Entering RFlisten mode...  packets arriving will be displayed on the screen (and returned in a list)"
-        print "(press Enter to stop)"
+        print("Entering RFlisten mode...  packets arriving will be displayed on the screen (and returned in a list)")
+        print("(press Enter to stop)")
         while not keystop():
 
             try:
                 y, t = self.RFrecv()
                 #print "(%5.3f) Received:  %s" % (t, y.encode('hex'))
-                print "(%5.3f) Received:  %s  | %s" % (t, y.encode('hex'), makeFriendlyAscii(y))
+                print("(%5.3f) Received:  %s  | %s" % (t, y.encode('hex'), makeFriendlyAscii(y)))
                 capture.append((y,t))
 
             except ChipconUsbTimeoutException:
                 pass
             except KeyboardInterrupt:
-                print "Please press <enter> to stop"
+                print("Please press <enter> to stop")
 
         sys.stdin.read(1)
         return capture
@@ -1455,13 +1459,13 @@ class NICxx11(USBDongle):
 
         if IdentSyncWord:
             if lowball <= 1:
-                print "Entering Discover mode and searching for possible SyncWords..."
+                print("Entering Discover mode and searching for possible SyncWords...")
                 if SyncWordMatchList != None:
-                    print "  seeking one of: %s" % repr([hex(x) for x in SyncWordMatchList])
+                    print("  seeking one of: %s" % repr([hex(x) for x in SyncWordMatchList]))
 
             else:
-                print "-- lowball too high -- ignoring request to IdentSyncWord"
-                print "Entering Discover mode..."
+                print("-- lowball too high -- ignoring request to IdentSyncWord")
+                print("Entering Discover mode...")
                 IdentSyncWord = False
 
         self.lowball(level=lowball, length=length)
@@ -1469,31 +1473,31 @@ class NICxx11(USBDongle):
             self._debug = debug
 
         if Search is not None:
-            print "Search:",repr(Search)
+            print("Search:",repr(Search))
 
         if RegExpSearch is not None:
-            print "RegExpSearch:",repr(RegExpSearch)
+            print("RegExpSearch:",repr(RegExpSearch))
 
-        print "(press Enter to quit)"
+        print("(press Enter to quit)")
         while not keystop():
 
             try:
                 y, t = self.RFrecv()
                 yhex = y.encode('hex')
 
-                print "(%5.3f) Received:  %s" % (t, yhex)
+                print("(%5.3f) Received:  %s" % (t, yhex))
                 if RegExpSearch is not None:
                     ynext = y
                     for loop in range(8):
                         if (re.search(RegExpSearch, ynext) is not None):
-                            print "    REG EXP SEARCH SUCCESS:",RegExpSearch
+                            print("    REG EXP SEARCH SUCCESS:",RegExpSearch)
                         ynext = bits.shiftString(ynext, 1)
 
                 if Search is not None:
                     ynext = y
                     for loop in range(8):
                         if (Search in ynext):
-                            print "    SEARCH SUCCESS:",Search
+                            print("    SEARCH SUCCESS:",Search)
                         ynext = bits.shiftString(ynext, 1)
 
                 if IdentSyncWord:
@@ -1502,7 +1506,7 @@ class NICxx11(USBDongle):
 
                     poss = bits.findSyncWord(y, ISWsensitivity, ISWminpreamble)
                     if len(poss):
-                        print "  possible Sync Dwords: %s" % repr([hex(x) for x in poss])
+                        print("  possible Sync Dwords: %s" % repr([hex(x) for x in poss]))
                         for dw in poss:
                             lst = retval.get(dw, 0)
                             lst += 1
@@ -1511,17 +1515,17 @@ class NICxx11(USBDongle):
                     if SyncWordMatchList is not None:
                         for x in poss:
                             if x in SyncWordMatchList:
-                                print "MATCH WITH KNOWN SYNC WORD:" + hex(x)
+                                print("MATCH WITH KNOWN SYNC WORD:" + hex(x))
 
             except ChipconUsbTimeoutException:
                 pass
             except KeyboardInterrupt:
-                print "Please press <enter> to stop"
+                print("Please press <enter> to stop")
 
         sys.stdin.read(1)
         self._debug = oldebug
         self.lowballRestore()
-        print "Exiting Discover mode..."
+        print("Exiting Discover mode...")
 
         if len(retval) == 0:
             return
@@ -1562,13 +1566,13 @@ class NICxx11(USBDongle):
 
     def lowballRestore(self):
         if not hasattr(self, '_last_radiocfg'):
-            raise(Exception("lowballRestore requires that lowball have been executed first (it saves radio config state!)"))
+            raise Exception
         self.setRadioConfig(self._last_radiocfg)
         self._last_radiocfg = ''
 
     ##### REPR FUNCTIONS #####
     def printRadioConfig(self, mhz=24, radiocfg=None):
-        print self.reprRadioConfig(mhz, radiocfg)
+        print(self.reprRadioConfig(mhz, radiocfg))
 
     def reprRadioConfig(self, mhz=24, radiocfg=None):
         if radiocfg == None:
@@ -1692,7 +1696,7 @@ class NICxx11(USBDongle):
         return "\n".join(output)
 
     def printRadioState(self, radiocfg=None):
-        print self.reprRadioState(radiocfg)
+        print(self.reprRadioState(radiocfg))
 
     def reprRadioState(self, radiocfg=None):
         output = []
@@ -1757,17 +1761,17 @@ class NICxx11(USBDongle):
         try:
             f = checkval.__class__(val.split(" ")[0])
             if abs(f-checkval) <= maxdiff:
-                print "  passed: reprRadioConfig test: %s %s" % (repr(val), checkval)
+                print("  passed: reprRadioConfig test: %s %s" % (repr(val), checkval))
             else:
-                print " *FAILED* reprRadioConfig test: %s %s %s" % (repr(line), repr(val), checkval)
+                print(" *FAILED* reprRadioConfig test: %s %s %s" % (repr(line), repr(val), checkval))
 
-        except ValueError, e:
-            print "  ERROR checking repr: %s" % e
+        except ValueError as e:
+            print("  ERROR checking repr: %s" % e)
 
     def testTX(self, data="XYZABCDEFGHIJKL"):
         while (sys.stdin not in select.select([sys.stdin],[],[],0)[0]):
             time.sleep(.4)
-            print "transmitting %s" % repr(data)
+            print("transmitting %s" % repr(data))
             self.RFxmit(data)
         sys.stdin.read(1)
 
@@ -2021,7 +2025,7 @@ class FHSSNIC(NICxx11):
         tick_ms = dwell_ms / (ticks_per_cycle * cycles_per_channel)
         val = calculateT2(tick_ms, mhz)
         T, tickidx, tipidx, PR = val
-        print "Setting MAC period to %f secs (%x %x %x)" % (val)
+        print("Setting MAC period to %f secs (%x %x %x)" % (val))
         t2ctl = (ord(self.peek(X_T2CTL)) & 0xfc)   | (tipidx)
         clkcon = (ord(self.peek(X_CLKCON)) & 0xc7) | (tickidx<<3)
         
@@ -2034,9 +2038,9 @@ class FHSSNIC(NICxx11):
         internal debugging use only
         '''
         macdata = self.getMACdata()
-        print repr(macdata)
+        print(repr(macdata))
         macdata = (_mode,) +  macdata[1:]
-        print repr(macdata)
+        print(repr(macdata))
         self.setMACdata(macdata)
 
     def setMACdata(self, data):
@@ -2100,17 +2104,17 @@ u16 synched_chans           %x
         return self.send(APP_NIC, FHSS_START_SYNC, struct.pack("<H",CellID))
                 
 def unittest(dongle):
-    import chipcon_usb
+    from . import chipcon_usb
     chipcon_usb.unittest(dongle)
 
-    print "\nTesting getValueFromReprString()"
+    print("\nTesting getValueFromReprString()")
     starry = dongle.reprRadioConfig().split('\n')
-    print repr(getValueFromReprString(starry, 'hz'))
+    print(repr(getValueFromReprString(starry, 'hz')))
 
-    print "\nTesting reprRadioConfig()"
-    print dongle.reprRadioConfig()
+    print("\nTesting reprRadioConfig()")
+    print(dongle.reprRadioConfig())
 
-    print "\nTesting Frequency Get/Setters"
+    print("\nTesting Frequency Get/Setters")
     # FREQ
     freq0,freq0str = dongle.getFreq()
 
@@ -2118,25 +2122,25 @@ def unittest(dongle):
     dongle.setFreq(testfreq)
     freq,freqstr = dongle.getFreq()
     if abs(testfreq - freq) < 1024:
-        print "  passed: %d : %f  (diff: %f)" % (testfreq, freq, testfreq-freq)
+        print("  passed: %d : %f  (diff: %f)" % (testfreq, freq, testfreq-freq))
     else:
-        print " *FAILED* %d : %f  (diff: %f)" % (testfreq, freq, testfreq-freq)
+        print(" *FAILED* %d : %f  (diff: %f)" % (testfreq, freq, testfreq-freq))
 
     testfreq = 868000000
     dongle.setFreq(testfreq)
     freq,freqstr = dongle.getFreq()
     if abs(testfreq - freq) < 1024:
-        print "  passed: %d : %f  (diff: %f)" % (testfreq, freq, testfreq-freq)
+        print("  passed: %d : %f  (diff: %f)" % (testfreq, freq, testfreq-freq))
     else:
-        print " *FAILED* %d : %f  (diff: %f)" % (testfreq, freq, testfreq-freq)
+        print(" *FAILED* %d : %f  (diff: %f)" % (testfreq, freq, testfreq-freq))
 
     testfreq = 433000000
     dongle.setFreq(testfreq)
     freq,freqstr = dongle.getFreq()
     if abs(testfreq - freq) < 1024:
-        print "  passed: %d : %f  (diff: %f)" % (testfreq, freq, testfreq-freq)
+        print("  passed: %d : %f  (diff: %f)" % (testfreq, freq, testfreq-freq))
     else:
-        print " *FAILED* %d : %f  (diff: %f)" % (testfreq, freq, testfreq-freq)
+        print(" *FAILED* %d : %f  (diff: %f)" % (testfreq, freq, testfreq-freq))
    
     dongle.checkRepr("Frequency:", float(testfreq), 1024)
     dongle.setFreq(freq0)
@@ -2147,9 +2151,9 @@ def unittest(dongle):
         dongle.setChannel(x)
         channr = dongle.getChannel()
         if channr != x:
-            print " *FAILED* get/setChannel():  %d : %d" % (x, channr)
+            print(" *FAILED* get/setChannel():  %d : %d" % (x, channr))
         else:
-            print "  passed: get/setChannel():  %d : %d" % (x, channr)
+            print("  passed: get/setChannel():  %d : %d" % (x, channr))
     dongle.checkRepr("Channel:", channr)
     dongle.setChannel(channr0)
 
@@ -2162,14 +2166,14 @@ def unittest(dongle):
         nfif  = dongle.getFsIF()
         nfoff = dongle.getFsOffset()
         if abs(nfif - fif) > 5:
-            print " *FAILED* get/setFsIFandOffset():  %d : %f (diff: %f)" % (fif,nfif,nfif-fif)
+            print(" *FAILED* get/setFsIFandOffset():  %d : %f (diff: %f)" % (fif,nfif,nfif-fif))
         else:
-            print "  passed: get/setFsIFandOffset():  %d : %f (diff: %f)" % (fif,nfif,nfif-fif)
+            print("  passed: get/setFsIFandOffset():  %d : %f (diff: %f)" % (fif,nfif,nfif-fif))
 
         if foff != nfoff:
-            print " *FAILED* get/setFsIFandOffset():  %d : %d (diff: %d)" % (foff,nfoff,nfoff-foff)
+            print(" *FAILED* get/setFsIFandOffset():  %d : %d (diff: %d)" % (foff,nfoff,nfoff-foff))
         else:
-            print "  passed: get/setFsIFandOffset():  %d : %d (diff: %d)" % (foff,nfoff,nfoff-foff)
+            print("  passed: get/setFsIFandOffset():  %d : %d (diff: %d)" % (foff,nfoff,nfoff-foff))
     dongle.checkRepr("Intermediate freq:", fif, 11720)
     dongle.checkRepr("Frequency Offset:", foff)
     
@@ -2183,73 +2187,73 @@ def unittest(dongle):
     dongle.setMdmModulation(mod, dongle.radiocfg)
     modcheck = dongle.getMdmModulation(dongle.radiocfg)
     if mod != modcheck:
-        print " *FAILED* get/setMdmModulation():  %d : %d " % (mod, modcheck)
+        print(" *FAILED* get/setMdmModulation():  %d : %d " % (mod, modcheck))
     else:
-        print "  passed: get/setMdmModulation():  %d : %d " % (mod, modcheck)
+        print("  passed: get/setMdmModulation():  %d : %d " % (mod, modcheck))
 
     chanspc = dongle.getMdmChanSpc(dongle.mhz, dongle.radiocfg)
     dongle.setMdmChanSpc(chanspc, dongle.mhz, dongle.radiocfg)
     chanspc_check = dongle.getMdmChanSpc(dongle.mhz, dongle.radiocfg)
     if chanspc != chanspc_check:
-        print " *FAILED* get/setMdmChanSpc():  %d : %d" % (chanspc, chanspc_check)
+        print(" *FAILED* get/setMdmChanSpc():  %d : %d" % (chanspc, chanspc_check))
     else:
-        print "  passed: get/setMdmChanSpc():  %d : %d" % (chanspc, chanspc_check)
+        print("  passed: get/setMdmChanSpc():  %d : %d" % (chanspc, chanspc_check))
 
     chanbw = dongle.getMdmChanBW(dongle.mhz, dongle.radiocfg)
     dongle.setMdmChanBW(chanbw, dongle.mhz, dongle.radiocfg)
     chanbw_check = dongle.getMdmChanBW(dongle.mhz, dongle.radiocfg)
     if chanbw != chanbw_check:
-        print " *FAILED* get/setMdmChanBW():  %d : %d" % (chanbw, chanbw_check)
+        print(" *FAILED* get/setMdmChanBW():  %d : %d" % (chanbw, chanbw_check))
     else:
-        print "  passed: get/setMdmChanBW():  %d : %d" % (chanbw, chanbw_check)
+        print("  passed: get/setMdmChanBW():  %d : %d" % (chanbw, chanbw_check))
 
     drate = dongle.getMdmDRate(dongle.mhz, dongle.radiocfg)
     dongle.setMdmDRate(drate, dongle.mhz, dongle.radiocfg)
     drate_check = dongle.getMdmDRate(dongle.mhz, dongle.radiocfg)
     if drate != drate_check:
-        print " *FAILED* get/setMdmDRate():  %d : %d" % (drate, drate_check)
+        print(" *FAILED* get/setMdmDRate():  %d : %d" % (drate, drate_check))
     else:
-        print "  passed: get/setMdmDRate():  %d : %d" % (drate, drate_check)
+        print("  passed: get/setMdmDRate():  %d : %d" % (drate, drate_check))
 
     deviatn = dongle.getMdmDeviatn(dongle.mhz, dongle.radiocfg)
     dongle.setMdmDeviatn(deviatn, dongle.mhz, dongle.radiocfg)
     deviatn_check = dongle.getMdmDeviatn(dongle.mhz, dongle.radiocfg)
     if deviatn != deviatn_check:
-        print " *FAILED* get/setMdmdeviatn():  %d : %d" % (deviatn, deviatn_check)
+        print(" *FAILED* get/setMdmdeviatn():  %d : %d" % (deviatn, deviatn_check))
     else:
-        print "  passed: get/setMdmdeviatn():  %d : %d" % (deviatn, deviatn_check)
+        print("  passed: get/setMdmdeviatn():  %d : %d" % (deviatn, deviatn_check))
 
     syncm = dongle.getMdmSyncMode(dongle.radiocfg)
     dongle.setMdmSyncMode(syncm, dongle.radiocfg)
     syncm_check = dongle.getMdmSyncMode(dongle.radiocfg)
     if syncm != syncm_check:
-        print " *FAILED* get/setMdmSyncMode():  %d : %d" % (syncm, syncm_check)
+        print(" *FAILED* get/setMdmSyncMode():  %d : %d" % (syncm, syncm_check))
     else:
-        print "  passed: get/setMdmSyncMode():  %d : %d" % (syncm, syncm_check)
+        print("  passed: get/setMdmSyncMode():  %d : %d" % (syncm, syncm_check))
 
     mchstr = dongle.getEnableMdmManchester(dongle.radiocfg)
     dongle.setEnableMdmManchester(mchstr, dongle.radiocfg)
     mchstr_check = dongle.getEnableMdmManchester(dongle.radiocfg)
     if mchstr != mchstr_check:
-        print " *FAILED* get/setMdmManchester():  %d : %d" % (mchstr, mchstr_check)
+        print(" *FAILED* get/setMdmManchester():  %d : %d" % (mchstr, mchstr_check))
     else:
-        print "  passed: get/setMdmManchester():  %d : %d" % (mchstr, mchstr_check)
+        print("  passed: get/setMdmManchester():  %d : %d" % (mchstr, mchstr_check))
 
     fec = dongle.getEnableMdmFEC(dongle.radiocfg)
     dongle.setEnableMdmFEC(fec, dongle.radiocfg)
     fec_check = dongle.getEnableMdmFEC(dongle.radiocfg)
     if fec != fec_check:
-        print " *FAILED* get/setEnableMdmFEC():  %d : %d" % (fec, fec_check)
+        print(" *FAILED* get/setEnableMdmFEC():  %d : %d" % (fec, fec_check))
     else:
-        print "  passed: get/setEnableMdmFEC():  %d : %d" % (fec, fec_check)
+        print("  passed: get/setEnableMdmFEC():  %d : %d" % (fec, fec_check))
 
     dcf = dongle.getEnableMdmDCFilter(dongle.radiocfg)
     dongle.setEnableMdmDCFilter(dcf, dongle.radiocfg)
     dcf_check = dongle.getEnableMdmDCFilter(dongle.radiocfg)
     if dcf != dcf_check:
-        print " *FAILED* get/setEnableMdmDCFilter():  %d : %d" % (dcf, dcf_check)
+        print(" *FAILED* get/setEnableMdmDCFilter():  %d : %d" % (dcf, dcf_check))
     else:
-        print "  passed: get/setEnableMdmDCFilter():  %d : %d" % (dcf, dcf_check)
+        print("  passed: get/setEnableMdmDCFilter():  %d : %d" % (dcf, dcf_check))
 
 
     # Pkt tests
@@ -2257,20 +2261,20 @@ def unittest(dongle):
     dongle.setPktPQT(pqt, dongle.radiocfg)
     pqt_check = dongle.getPktPQT(dongle.radiocfg)
     if pqt != pqt_check:
-        print " *FAILED* get/setEnableMdmFEC():  %d : %d" % (pqt, pqt_check)
+        print(" *FAILED* get/setEnableMdmFEC():  %d : %d" % (pqt, pqt_check))
     else:
-        print "  passed: get/setEnableMdmFEC():  %d : %d" % (pqt, pqt_check)
+        print("  passed: get/setEnableMdmFEC():  %d : %d" % (pqt, pqt_check))
 
     # FHSS tests
-    print "\nTesting FHSS State set/get"
+    print("\nTesting FHSS State set/get")
     fhssstate = dongle.getFHSSstate()
-    print repr(fhssstate)
+    print(repr(fhssstate))
     for stateidx in range(FHSS_LAST_STATE+1):
-        print repr(dongle.setFHSSstate(stateidx))
-        print repr(dongle.getFHSSstate())
+        print(repr(dongle.setFHSSstate(stateidx)))
+        print(repr(dongle.getFHSSstate()))
 
-    print repr(dongle.setFHSSstate(fhssstate[1] ))
-    print repr(dongle.getFHSSstate())
+    print(repr(dongle.setFHSSstate(fhssstate[1] )))
+    print(repr(dongle.getFHSSstate()))
 
 def getValueFromReprString(stringarray, line_text):
     for string in stringarray:

--- a/rflib/chipcon_nic.py
+++ b/rflib/chipcon_nic.py
@@ -603,7 +603,7 @@ class NICxx11(USBDongle):
             radiocfg = self.radiocfg
 
         if (mod) & ~MDMCFG2_MOD_FORMAT:
-            raise Exception
+            raise Exception("Please use constants MOD_FORMAT_* to specify modulation and ")
 
         radiocfg.mdmcfg2 &= ~MDMCFG2_MOD_FORMAT
         radiocfg.mdmcfg2 |= (mod)
@@ -662,7 +662,7 @@ class NICxx11(USBDongle):
                     chanspc_m = m
                     break
         if chanspc_e is None or chanspc_m is None:
-            raise Exception
+            raise Exception("ChanSpc does not translate into acceptable parameters.  Should you be changing this?")
 
         #chanspc = 1000000.0 * mhz/pow(2,18) * (256 + chanspc_m) * pow(2, chanspc_e)
         #print "chanspc_e: %x   chanspc_m: %x   chanspc: %f hz" % (chanspc_e, chanspc_m, chanspc)
@@ -679,7 +679,7 @@ class NICxx11(USBDongle):
             radiocfg = self.radiocfg
 
         if maxlen > RF_MAX_TX_BLOCK:
-            raise Exception
+            raise Exception("Packet too large (%d bytes). Maximum variable length packet is %d bytes." % (maxlen, RF_MAX_TX_BLOCK))
 
         radiocfg.pktctrl0 &= ~PKTCTRL0_LENGTH_CONFIG
         radiocfg.pktctrl0 |= 1
@@ -694,7 +694,7 @@ class NICxx11(USBDongle):
             radiocfg = self.radiocfg
 
         if flen > EP5OUT_BUFFER_SIZE - 4:
-            raise Exception
+            raise Exception("Packet too large (%d bytes). Maximum fixed length packet is %d bytes." % (flen, EP5OUT_BUFFER_SIZE - 6))
 
         radiocfg.pktctrl0 &= ~PKTCTRL0_LENGTH_CONFIG
         # if we're sending a large block, pktlen is dealt with by the firmware
@@ -862,7 +862,7 @@ class NICxx11(USBDongle):
         ifBits = int(ifBits + .5)       # rounded evenly
 
         if ifBits >0x1f:
-            raise Exception
+            raise Exception("FAIL:  freq_if is too high?  freqbits: %x (must be <0x1f)" % ifBits)
         radiocfg.fsctrl1 &= ~(0x1f)
         radiocfg.fsctrl1 |= int(ifBits)
         self.setRFRegister(FSCTRL1, (radiocfg.fsctrl1))
@@ -961,7 +961,7 @@ class NICxx11(USBDongle):
                 chanbw_m = m
                 break
         if chanbw_e is None:
-            raise Exception
+            raise Exception("ChanBW does not translate into acceptable parameters.  Should you be changing this?")
 
         bw = 1000.0*mhz / (8.0*(4+chanbw_m) * pow(2,chanbw_e))
         #print "chanbw_e: %x   chanbw_m: %x   chanbw: %f kHz" % (e, m, bw)
@@ -1011,7 +1011,7 @@ class NICxx11(USBDongle):
                 drate_m = m
                 break
         if drate_e is None:
-            raise Exception
+            raise Exception("DRate does not translate into acceptable parameters.  Should you be changing this?")
 
         drate = 1000000.0 * mhz * (256+drate_m) * pow(2,drate_e) / pow(2,28)
         if self._debug: print("drate_e: %x   drate_m: %x   drate: %f Hz" % (drate_e, drate_m, drate))
@@ -1055,7 +1055,7 @@ class NICxx11(USBDongle):
                 dev_m = m
                 break
         if dev_e is None:
-            raise Exception
+            raise Exception("Deviation does not translate into acceptable parameters.  Should you be changing this?")
 
         dev = 1000000.0 * mhz * (8+dev_m) * pow(2,dev_e) / pow(2,17)
         #print "dev_e: %x   dev_m: %x   deviatn: %f Hz" % (e, m, dev)
@@ -1384,7 +1384,7 @@ class NICxx11(USBDongle):
     def RFrecv(self, timeout=USB_RX_WAIT, blocksize=None):
         if not blocksize == None:
             if blocksize > EP5OUT_BUFFER_SIZE: 
-                raise Exception("Blocksize too large. Maximum %d")
+                raise Exception("Blocksize too large. Maximum %d" % EP5OUT_BUFFER_SIZE)
             self.send(APP_NIC, NIC_SET_RECV_LARGE, "%s" % struct.pack("<H",blocksize))
         data = self.recv(APP_NIC, NIC_RECV, timeout)
         # decode, if necessary
@@ -1566,7 +1566,7 @@ class NICxx11(USBDongle):
 
     def lowballRestore(self):
         if not hasattr(self, '_last_radiocfg'):
-            raise Exception
+            raise Exception("lowballRestore requires that lowball have been executed first (it saves radio config state!)")
         self.setRadioConfig(self._last_radiocfg)
         self._last_radiocfg = ''
 

--- a/rflib/chipcon_usb.py
+++ b/rflib/chipcon_usb.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env ipython
+
+from __future__ import print_function
+from __future__ import absolute_import
+
 import os
 import sys
 import usb
@@ -7,10 +11,10 @@ import struct
 import select
 import threading
 
-import bits
-from chipcondefs import *
-from rflib_defs import *
-from rflib_version import *
+from . import bits
+from .chipcondefs import *
+from .rflib_defs import *
+from .rflib_version import *
 
 if os.name == 'nt':
     import msvcrt
@@ -151,7 +155,7 @@ def getRfCatDevices():
                 rfcats.append(dev)
 
             elif (dev.idVendor == 0x1d50 and (dev.idProduct == 0x6049 or dev.idProduct == 0x604a or dev.idProduct == 0xecc0)):
-                print "Already in Bootloader Mode... exiting"
+                print("Already in Bootloader Mode... exiting")
                 exit(0)
 
     return rfcats
@@ -243,7 +247,7 @@ class USBDongle:
         self.ep5timeout = EP_TIMEOUT_ACTIVE
 
         for dev in getRfCatDevices():
-            if self._debug: print >>sys.stderr,(dev)
+            if self._debug: print((dev), file=sys.stderr)
             do = dev.open()
             iSN = do.getDescriptor(1,0,50)[16]
             devnum = dev.devnum
@@ -251,7 +255,7 @@ class USBDongle:
 
         dongles.sort()
         if len(dongles) == 0:
-            raise(Exception("No Dongle Found.  Please insert a RFCAT dongle."))
+            raise Exception
 
         self.rsema = threading.Lock()
         self.xsema = threading.Lock()
@@ -261,8 +265,8 @@ class USBDongle:
         
         try:
             do.claimInterface(0)
-        except Exception,e:
-            if console or self._debug: print >>sys.stderr,("Error claiming usb interface:" + repr(e))
+        except Exception as e:
+            if console or self._debug: print(("Error claiming usb interface:" + repr(e)), file=sys.stderr)
 
 
 
@@ -287,7 +291,7 @@ class USBDongle:
         self.chipstr = chipstr
 
         if chip == None:
-            print "Older firmware, consider upgrading."
+            print("Older firmware, consider upgrading.")
         else:
             self.chipstr = "unrecognized dongle: %s" % chip
 
@@ -303,7 +307,7 @@ class USBDongle:
         self._do=None
         if self._bootloader: 
             return
-        if self._debug: print >>sys.stderr,("waiting (resetup) %x" % self.idx)
+        if self._debug: print(("waiting (resetup) %x" % self.idx), file=sys.stderr)
         while (self._do==None):
             try:
                 self.setup(console, copyDongle)
@@ -312,10 +316,10 @@ class USBDongle:
                 self.ping(3, wait=10, silent=True)
                 self.setRfMode(self._rfmode)
 
-            except Exception, e:
+            except Exception as e:
                 #if console: sys.stderr.write('.')
                 if not self._quiet:
-                    print >>sys.stderr,("Error in resetup():" + repr(e))
+                    print(("Error in resetup():" + repr(e)), file=sys.stderr)
                 #if console or self._debug: print >>sys.stderr,("Error in resetup():" + repr(e))
                 time.sleep(1)
 
@@ -345,22 +349,22 @@ class USBDongle:
             drain = buf[:self._usbmaxo]
             buf = buf[self._usbmaxo:]
 
-            if self._debug: print >>sys.stderr,"XMIT:"+repr(drain)
+            if self._debug: print("XMIT:"+repr(drain), file=sys.stderr)
             try:
                 numwrt = self._do.bulkWrite(5, drain, timeout)
                 if numwrt != len(drain):
                     raise Exception("Didn't write all the data!? Sent: %d != Queued: %d.  REqueuing!(this may be the wrong thing to do, swat me if so)" % (numwrt, len(drain)))
-            except Exception, e:
-                if self._debug: print >>sys.stderr,"requeuing on error '%s' (%s)" % (repr(drain), e)
+            except Exception as e:
+                if self._debug: print("requeuing on error '%s' (%s)" % (repr(drain), e), file=sys.stderr)
                 self.xsema.acquire()
                 msg = self.xmit_queue.insert(0, drain)
                 self.xmit_event.set()
                 self.xsema.release()
-                if self._debug: print >>sys.stderr, repr(self.xmit_queue)
+                if self._debug: print(repr(self.xmit_queue), file=sys.stderr)
         
     def _recvEP5(self, timeout=100):
         retary = ["%c"%x for x in self._do.bulkRead(0x85, 500, timeout)]
-        if self._debug: print >>sys.stderr,"RECV:"+repr(retary)
+        if self._debug: print("RECV:"+repr(retary), file=sys.stderr)
         if len(retary):
             return ''.join(retary)
         return ''
@@ -369,7 +373,7 @@ class USBDongle:
         threadGoSet = self._threadGo.isSet()
         self._threadGo.clear()
         if self._debug:
-            print >>sys.stderr,("_clear_buffers()")
+            print(("_clear_buffers()"), file=sys.stderr)
         if clear_recv_mbox:
             for key in self.recv_mbox.keys():
                 self.trash.extend(self.recvAll(key))
@@ -432,7 +436,7 @@ class USBDongle:
                         q = b[cmd]
                         if len(q):
                             buf,timestamp = q.pop(0)
-                            if self._debug > 1: print >>sys.stderr,("recvthread: buf length: %x\t\t cmd: %x\t\t(%s)"%(len(buf), cmd, repr(buf)))
+                            if self._debug > 1: print(("recvthread: buf length: %x\t\t cmd: %x\t\t(%s)"%(len(buf), cmd, repr(buf))), file=sys.stderr)
 
                             if (cmd == DEBUG_CMD_STRING):
                                 if (len(buf) < 4):
@@ -443,7 +447,7 @@ class USBDongle:
                                     if self._debug: sys.stderr.write('*')
                                 else:
                                     length, = struct.unpack("<H", buf[2:4])
-                                    if self._debug >1: print >>sys.stderr,("len=%d"%length)
+                                    if self._debug >1: print(("len=%d"%length), file=sys.stderr)
                                     if (len(buf) < 4+length):
                                         if (len(q)):
                                             buf2 = q.pop(0)
@@ -454,39 +458,39 @@ class USBDongle:
                                         printbuf = buf[4:4+length]
                                         requeuebuf = buf[4+length:]
                                         if len(requeuebuf):
-                                            if self._debug>1:  print >>sys.stderr,(" - DEBUG..requeuing %s"%repr(requeuebuf))
+                                            if self._debug>1:  print((" - DEBUG..requeuing %s"%repr(requeuebuf)), file=sys.stderr)
                                             q.insert(0,requeuebuf)
-                                        print >>sys.stderr,("DEBUG: (%.3f) %s" % (timestamp, repr(printbuf)))
+                                        print(("DEBUG: (%.3f) %s" % (timestamp, repr(printbuf))), file=sys.stderr)
                             elif (cmd == DEBUG_CMD_HEX):
                                 #print >>sys.stderr, repr(buf)
-                                print >>sys.stderr, "DEBUG: (%.3f) 0x%x %d"%(timestamp, struct.unpack("B", buf[4:5])[0], struct.unpack("B", buf[4:5])[0])
+                                print("DEBUG: (%.3f) 0x%x %d"%(timestamp, struct.unpack("B", buf[4:5])[0], struct.unpack("B", buf[4:5])[0]), file=sys.stderr)
                             elif (cmd == DEBUG_CMD_HEX16):
                                 #print >>sys.stderr, repr(buf)
-                                print >>sys.stderr, "DEBUG: (%.3f) 0x%x %d"%(timestamp, struct.unpack("<H", buf[4:6])[0], struct.unpack("<H", buf[4:6])[0])
+                                print("DEBUG: (%.3f) 0x%x %d"%(timestamp, struct.unpack("<H", buf[4:6])[0], struct.unpack("<H", buf[4:6])[0]), file=sys.stderr)
                             elif (cmd == DEBUG_CMD_HEX32):
                                 #print >>sys.stderr, repr(buf)
-                                print >>sys.stderr, "DEBUG: (%.3f) 0x%x %d"%(timestamp, struct.unpack("<L", buf[4:8])[0], struct.unpack("<L", buf[4:8])[0])
+                                print("DEBUG: (%.3f) 0x%x %d"%(timestamp, struct.unpack("<L", buf[4:8])[0], struct.unpack("<L", buf[4:8])[0]), file=sys.stderr)
                             elif (cmd == DEBUG_CMD_INT):
-                                print >>sys.stderr, "DEBUG: (%.3f) %d"%(timestamp, struct.unpack("<L", buf[4:8])[0])
+                                print("DEBUG: (%.3f) %d"%(timestamp, struct.unpack("<L", buf[4:8])[0]), file=sys.stderr)
                             else:
-                                print >>sys.stderr,('DEBUG COMMAND UNKNOWN: %x (buf=%s)'%(cmd,repr(buf)))
+                                print(('DEBUG COMMAND UNKNOWN: %x (buf=%s)'%(cmd,repr(buf))), file=sys.stderr)
 
             except:
                 sys.excepthook(*sys.exc_info())
 
             #### receive stuff.
-            if self._debug>2: print >> sys.stderr, "recvthread: Doing receiving...",self.ep5timeout
+            if self._debug>2: print("recvthread: Doing receiving...",self.ep5timeout, file=sys.stderr)
             try:
                 #### first we populate the queue
                 msg = self._recvEP5(timeout=self.ep5timeout)
                 if len(msg) > 0:
                     self.recv_queue += msg
                     msgrecv = True
-            except usb.USBError, e:
+            except usb.USBError as e:
                 #sys.stderr.write(repr(self.recv_queue))
                 #sys.stderr.write(repr(e))
                 errstr = repr(e)
-                if self._debug>4: print >>sys.stderr,repr(sys.exc_info())
+                if self._debug>4: print(repr(sys.exc_info()), file=sys.stderr)
                 if ('No error' in errstr):
                     pass
                 elif ('Connection timed out' in errstr):
@@ -495,27 +499,27 @@ class USBDongle:
                     pass
                 else:
                     if ('could not release intf' in errstr):
-                        if self._debug: print "skipping"
+                        if self._debug: print("skipping")
                         pass
                     elif ('No such device' in errstr):
                         self._threadGo.clear()
                         #self.resetup(False) ## THIS IS A PROBLEM.
                         self.reset_event.set()
-                        print "===== RESETUP set from recv thread"
+                        print("===== RESETUP set from recv thread")
                     elif ('Input/output error' in errstr):  # USBerror 5
                         self._threadGo.clear()
                         #self.resetup(False) ## THIS IS A PROBLEM.
                         self.reset_event.set()
-                        print "===== RESETUP set from recv thread"
+                        print("===== RESETUP set from recv thread")
 
                     else:
-                        if self._debug: print "Error in runEP5() (receiving): %s" % errstr
+                        if self._debug: print("Error in runEP5() (receiving): %s" % errstr)
                         if self._debug>2: sys.excepthook(*sys.exc_info())
                     self._usberrorcnt += 1
                 pass
-            except AttributeError,e:
+            except AttributeError as e:
                 if "'NoneType' object has no attribute 'bInterfaceNumber'" in str(e):
-                    print "Error: dongle went away.  USB bus problems?"
+                    print("Error: dongle went away.  USB bus problems?")
                     self._threadGo.clear()
                     #self.resetup(False)
                     self.reset_event.set()
@@ -523,7 +527,7 @@ class USBDongle:
             except:
                 sys.excepthook(*sys.exc_info())
 
-            if self._debug>2: print >> sys.stderr, "recvthread: Sorting mail..."
+            if self._debug>2: print("recvthread: Sorting mail...", file=sys.stderr)
             #### parse, sort, and deliver the mail.
             try:
                 # FIXME: is this robust?  or just overcomplex?
@@ -534,7 +538,7 @@ class USBDongle:
                             sys.stderr.write('@')
                     else:
                         if (idx>0):
-                            if self._debug: print >>sys.stderr,("runEP5(): idx>0?")
+                            if self._debug: print(("runEP5(): idx>0?"), file=sys.stderr)
                             self.trash.append(self.recv_queue[:idx])
                             self.recv_queue = self.recv_queue[idx:]
                    
@@ -550,7 +554,7 @@ class USBDongle:
                             cmd = ord(msg[2])
                             length, = struct.unpack("<H", msg[3:5])
 
-                            if self._debug>1: print>>sys.stderr,("recvthread: app=%x  cmd=%x  len=%x"%(app,cmd,length))
+                            if self._debug>1: print(("recvthread: app=%x  cmd=%x  len=%x"%(app,cmd,length)), file=sys.stderr)
 
                             if (msglen >= length+5):
                                 #### if the queue has enough characters to handle the next message... chop it and put it in the appropriate recv_mbox
@@ -598,7 +602,7 @@ class USBDongle:
             except:
                 sys.excepthook(*sys.exc_info())
 
-            if self._debug>2: print >> sys.stderr, "readthread: Loop finished"
+            if self._debug>2: print("readthread: Loop finished", file=sys.stderr)
             if not (msgrecv or len(msg)) :
                 #time.sleep(.1)
                 self.ep5timeout = EP_TIMEOUT_IDLE
@@ -623,7 +627,7 @@ class USBDongle:
             try:
                 b = self.recv_mbox.get(app)
                 if b:
-                    if self._debug: print>>sys.stderr, "Recv msg",app,b,cmd
+                    if self._debug: print("Recv msg",app,b,cmd, file=sys.stderr)
                     if cmd is None:
                         keys = b.keys()
                         if len(keys):
@@ -631,15 +635,15 @@ class USBDongle:
 
                 if b is not None and cmd is not None:
                     q = b.get(cmd)
-                    if self._debug: print >>sys.stderr,"debug(recv) q='%s'"%repr(q)
+                    if self._debug: print("debug(recv) q='%s'"%repr(q), file=sys.stderr)
 
                     if q is not None and self.rsema.acquire(False):
-                        if self._debug>3: print ("rsema.UNlocked", "rsema.locked")[self.rsema.locked()],2
+                        if self._debug>3: print(("rsema.UNlocked", "rsema.locked")[self.rsema.locked()],2)
                         try:
                             resp, rt = q.pop(0)
 
                             self.rsema.release()
-                            if self._debug>3: print ("rsema.UNlocked", "rsema.locked")[self.rsema.locked()],2
+                            if self._debug>3: print(("rsema.UNlocked", "rsema.locked")[self.rsema.locked()],2)
 
                             # bring it on home...  this is the way out.
                             return resp[4:], rt
@@ -662,7 +666,7 @@ class USBDongle:
             except:
                 sys.excepthook(*sys.exc_info())
 
-        raise(ChipconUsbTimeoutException())
+        raise ChipconUsbTimeoutException
 
     def recvAll(self, app, cmd=None):
         retval = self.recv_mbox.get(app,None)
@@ -697,7 +701,7 @@ class USBDongle:
         self.xmit_queue.append(msg)
         self.xmit_event.set()
         self.xsema.release()
-        if self._debug: print "Sent Msg",msg.encode("hex")
+        if self._debug: print("Sent Msg",msg.encode("hex"))
         return self.recv(app, cmd, wait)
 
     def reprDebugCodes(self, timeout=100):
@@ -752,10 +756,10 @@ class USBDongle:
             #r = self._recvEP0(3, 10)
             try:
                 r = self._recvEP0(request=2, value=count, length=count, timeout=DEFAULT_USB_TIMEOUT)
-                print "PING: %d bytes received: %s"%(len(r), repr(r))
-            except ChipconUsbTimeoutException, e:
+                print("PING: %d bytes received: %s"%(len(r), repr(r)))
+            except ChipconUsbTimeoutException as e:
                 r = None
-                print "Ping Failed.",e
+                print("Ping Failed.",e)
             if r==None:
                 bad+=1
             else:
@@ -775,8 +779,8 @@ class USBDongle:
             for x in self.recv_mbox.keys():
                 print >>sys.stderr,('    recv_mbox   %d\t (%d records)  "%s"'%(x,len(self.recv_mbox[x]),repr(self.recv_mbox[x])[:len(repr(self.recv_mbox[x]))%79]))
                 """
-            print self.reprRadioState()
-            print self.reprClientState()
+            print(self.reprRadioState())
+            print(self.reprClientState())
 
             x,y,z = select.select([sys.stdin],[],[], delay)
             if sys.stdin in x:
@@ -787,9 +791,9 @@ class USBDongle:
         try:
             r = self.send(APP_SYSTEM, SYS_CMD_PARTNUM, "", 10000)
             r,rt = r
-        except ChipconUsbTimeoutException, e:
+        except ChipconUsbTimeoutException as e:
             r = None
-            print "SETUP Failed.",e
+            print("SETUP Failed.",e)
 
         return ord(r)
 
@@ -806,11 +810,11 @@ class USBDongle:
                 r,rt = r
                 istop = time.time()
                 if not silent:
-                    print "PING: %d bytes transmitted, received: %s (%f seconds)"%(len(buf), repr(r), istop-istart)
-            except ChipconUsbTimeoutException, e:
+                    print("PING: %d bytes transmitted, received: %s (%f seconds)"%(len(buf), repr(r), istop-istart))
+            except ChipconUsbTimeoutException as e:
                 r = None
                 if not silent:
-                    print "Ping Failed.",e
+                    print("Ping Failed.",e)
             if r==None:
                 bad+=1
             else:
@@ -910,7 +914,7 @@ class USBDongle:
         return "\n".join(output)
 
     def printClientState(self, width=120):
-        print self.reprClientState(width)
+        print(self.reprClientState(width))
 
     def reprClientState(self, width=120):
         output = ["="*width]
@@ -930,31 +934,31 @@ class USBDongle:
 
 
 def unittest(self, mhz=24):
-    print "\nTesting USB ping()"
+    print("\nTesting USB ping()")
     self.ping(3)
     
-    print "\nTesting USB ep0Ping()"
+    print("\nTesting USB ep0Ping()")
     self.ep0Ping()
     
-    print "\nTesting USB enumeration"
-    print "getString(0,100): %s" % repr(self._do.getString(0,100))
+    print("\nTesting USB enumeration")
+    print("getString(0,100): %s" % repr(self._do.getString(0,100)))
     
-    print "\nTesting USB EP MAX_PACKET_SIZE handling (ep0Peek(0xf000, 100))"
-    print repr(self.ep0Peek(0xf000, 100))
+    print("\nTesting USB EP MAX_PACKET_SIZE handling (ep0Peek(0xf000, 100))")
+    print(repr(self.ep0Peek(0xf000, 100)))
 
-    print "\nTesting USB EP MAX_PACKET_SIZE handling (peek(0xf000, 300))"
-    print repr(self.peek(0xf000, 400))
+    print("\nTesting USB EP MAX_PACKET_SIZE handling (peek(0xf000, 300))")
+    print(repr(self.peek(0xf000, 400)))
 
-    print "\nTesting USB poke/peek"
+    print("\nTesting USB poke/peek")
     data = "".join([chr(c) for c in xrange(120)])
     where = 0xf300
     self.poke(where, data)
     ndata = self.peek(where, len(data))
     if ndata != data:
-        print " *FAILED*\n '%s'\n '%s'" % (data.encode("hex"), ndata.encode("hex"))
-        raise(Exception(" *FAILED*\n '%s'\n '%s'" % (data.encode("hex"), ndata.encode("hex"))))
+        print(" *FAILED*\n '%s'\n '%s'" % (data.encode("hex"), ndata.encode("hex")))
+        raise Exception
     else:
-        print "  passed  '%s'" % (ndata.encode("hex"))
+        print("  passed  '%s'" % (ndata.encode("hex")))
 
 
 if __name__ == "__main__":

--- a/rflib/chipcon_usb.py
+++ b/rflib/chipcon_usb.py
@@ -255,7 +255,7 @@ class USBDongle:
 
         dongles.sort()
         if len(dongles) == 0:
-            raise Exception
+            raise Exception("No Dongle Found.  Please insert a RFCAT dongle.")
 
         self.rsema = threading.Lock()
         self.xsema = threading.Lock()
@@ -956,7 +956,7 @@ def unittest(self, mhz=24):
     ndata = self.peek(where, len(data))
     if ndata != data:
         print(" *FAILED*\n '%s'\n '%s'" % (data.encode("hex"), ndata.encode("hex")))
-        raise Exception
+        raise Exception(" *FAILED*\n '%s'\n '%s'" % (data.encode("hex"), ndata.encode("hex")))
     else:
         print("  passed  '%s'" % (ndata.encode("hex")))
 

--- a/rflib/intelhex.py
+++ b/rflib/intelhex.py
@@ -37,9 +37,9 @@
 @version    1.1
 '''
 
-
 __docformat__ = "javadoc"
 
+from __future__ import print_function
 
 from array import array
 from binascii import hexlify, unhexlify
@@ -254,7 +254,7 @@ class IntelHex(object):
         """
         s = dikt.copy()
         start_addr = s.get('start_addr')
-        if s.has_key('start_addr'):
+        if 'start_addr' in s:
             del s['start_addr']
         for k in s.keys():
             if type(k) not in (int, long) or k < 0:
@@ -847,8 +847,8 @@ def hex2bin(fin, fout, start=None, end=None, size=None, pad=0xFF):
     """
     try:
         h = IntelHex(fin)
-    except HexReaderError, e:
-        print "ERROR: bad HEX file: %s" % str(e)
+    except HexReaderError as e:
+        print("ERROR: bad HEX file: %s" % str(e))
         return 1
 
     # start, end, size
@@ -865,8 +865,8 @@ def hex2bin(fin, fout, start=None, end=None, size=None, pad=0xFF):
 
     try:
         h.tobinfile(fout, start, end, pad)
-    except IOError, e:
-        print "ERROR: Could not write to file: %s: %s" % (fout, str(e))
+    except IOError as e:
+        print("ERROR: Could not write to file: %s: %s" % (fout, str(e)))
         return 1
 
     return 0
@@ -884,14 +884,14 @@ def bin2hex(fin, fout, offset=0):
     h = IntelHex()
     try:
         h.loadbin(fin, offset)
-    except IOError, e:
-        print 'ERROR: unable to load bin file:', str(e)
+    except IOError as e:
+        print('ERROR: unable to load bin file:', str(e))
         return 1
 
     try:
         h.tofile(fout, format='hex')
-    except IOError, e:
-        print "ERROR: Could not write to file: %s: %s" % (fout, str(e))
+    except IOError as e:
+        print("ERROR: Could not write to file: %s: %s" % (fout, str(e)))
         return 1
 
     return 0
@@ -1063,7 +1063,7 @@ class IntelHexError(Exception):
             return self.msg
         try:
             return self._fmt % self.__dict__
-        except (NameError, ValueError, KeyError), e:
+        except (NameError, ValueError, KeyError) as e:
             return 'Unprintable exception %s: %s' \
                 % (self.__class__.__name__, str(e))
 


### PR DESCRIPTION
This PR is porting the Python 2 code to Python 3 without losing compatibility for Python 2.7 according to https://python-future.org/futurize.html.

~**Note:** this PR is still work in progress!~

### Description:

Stage 1 will apply fixes to modernize the Python 2 code without changing the effect of the code. The goal of this stage is to create most of the diff for the entire porting process, but without introducing any bugs.

Stage 2 will add a dependency on the `future` package. The goal for stage 2 is to make further mostly safe changes to the Python 2 code to use Python 3 style code that still runs on Python 2 with the help of the appropriate builtins and utilities in `future`.

In stage 3 we will be separating text from bytes manually by prefixing all the string literals with either `b` or `u` accordingly. To ensure that these type behave similarly on Python 2 as on Python 3, we will wrap byte-strings or text in the `bytes` and `str` types from `future`.

After running `futurize`, we start by testing compatibility on Python 3 and making further code changes until it's fully compatible with Python 3. The next step is to make manual tweaks to the code to re-enable Python 2 compatibility.

### Action Items:

- [x] Drop support for Python 2.6 and older (#33 )
- [x] Stage 1 of `futurize` (_except for `vstruct/*`_)
- [x] Manually fix commented code and exception messages that aren't correctly ported by `futurize`.
- [ ] Merge stage 1 changes into master (_most of the diff, minimal to no impact_) 
- [ ] Stage 2 of `futurize` (_except for `vstruct/*`_)
- [ ] Merge stage 2 changes into master
- [ ] Stage 1 and 2 of `futurize` in `vstruct/*`
- [ ] Merge `futurize` changes in `vstruct/*` into master
- [ ] Separating text from bytes manually
- [ ] Test & make the code pass on Python 3
- [ ] Manually tweak to re-enable Python 2 compatibility
- [ ] Merge changes into master

### Additional Information:

This PR is part of fixing #15.
