### PR TITLE
udev rule cleanup

### DIFF
--- a/etc/udev/rules.d/20-rfcat.rules
+++ b/etc/udev/rules.d/20-rfcat.rules
@@ -1,14 +1,16 @@
 # legacy RfCats and cc1111usb
-SUBSYSTEMS=="usb" ATTRS{idVendor}=="0451" ATTRS{idProduct}=="4715" MODE:="0660" SYMLINK+="RFCAT%n", GROUP="dialout"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="0451", ATTRS{idProduct}=="4715", MODE:="0660", SYMLINK+="RFCAT%n", GROUP="dialout"
 
 # modern RfCats
-SUBSYSTEMS=="usb" ATTRS{idVendor}=="1d50" ATTRS{idProduct}=="6047" MODE:="0660" SYMLINK+="RFCAT%n", GROUP="dialout"
-SUBSYSTEMS=="usb" ATTRS{idVendor}=="1d50" ATTRS{idProduct}=="6048" MODE:="0660" SYMLINK+="RFCAT%n", GROUP="dialout"
-SUBSYSTEMS=="usb" ATTRS{idVendor}=="1d50" ATTRS{idProduct}=="605b" MODE:="0660" SYMLINK+="RFCAT%n", GROUP="dialout"
-SUBSYSTEMS=="usb" ATTRS{idVendor}=="1d50" ATTRS{idProduct}=="ecc1" MODE:="0660" SYMLINK+="RFCAT%n", GROUP="dialout"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="1d50", ATTRS{idProduct}=="6047", MODE:="0660", SYMLINK+="RFCAT%n", GROUP="dialout"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="1d50", ATTRS{idProduct}=="6048", MODE:="0660", SYMLINK+="RFCAT%n", GROUP="dialout"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="1d50", ATTRS{idProduct}=="605b", MODE:="0660", SYMLINK+="RFCAT%n", GROUP="dialout"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="1d50", ATTRS{idProduct}=="ecc1", MODE:="0660", SYMLINK+="RFCAT%n", GROUP="dialout"
+
+
 
 # RfCat bootloader subsystem (uses it's own product id)
-SUBSYSTEMS=="usb" ATTRS{idVendor}=="1d50" ATTRS{idProduct}=="6049" SYMLINK+="RFCAT_BL_C" ENV{ID_MM_DEVICE_IGNORE}="1"
-SUBSYSTEMS=="usb" ATTRS{idVendor}=="1d50" ATTRS{idProduct}=="604a" SYMLINK+="RFCAT_BL_D" ENV{ID_MM_DEVICE_IGNORE}="1"
-SUBSYSTEMS=="usb" ATTRS{idVendor}=="1d50" ATTRS{idProduct}=="605c" SYMLINK+="RFCAT_BL_YS1" ENV{ID_MM_DEVICE_IGNORE}="1"
-SUBSYSTEMS=="usb" ATTRS{idVendor}=="1d50" ATTRS{idProduct}=="ecc0" SYMLINK+="RFCAT_BL_SRF" ENV{ID_MM_DEVICE_IGNORE}="1"
+SUBSYSTEM=="tty", SUBSYSTEMS=="usb", ATTRS{idVendor}=="1d50", ATTRS{idProduct}=="6049", MODE:="0660", SYMLINK+="RFCAT_BL_C", ENV{ID_MM_DEVICE_IGNORE}="1", GROUP="dialout"
+SUBSYSTEM=="tty", SUBSYSTEMS=="usb", ATTRS{idVendor}=="1d50", ATTRS{idProduct}=="604a", MODE:="0660", SYMLINK+="RFCAT_BL_D", ENV{ID_MM_DEVICE_IGNORE}="1", GROUP="dialout"
+SUBSYSTEM=="tty", SUBSYSTEMS=="usb", ATTRS{idVendor}=="1d50", ATTRS{idProduct}=="605c", MODE:="0660", SYMLINK+="RFCAT_BL_YS1", ENV{ID_MM_DEVICE_IGNORE}="1", GROUP="dialout"
+SUBSYSTEM=="tty", SUBSYSTEMS=="usb", ATTRS{idVendor}=="1d50", ATTRS{idProduct}=="ecc0", MODE:="0660", SYMLINK+="RFCAT_BL_SRF", ENV{ID_MM_DEVICE_IGNORE}="1", GROUP="dialout"

--- a/etc/udev/rules.d/20-rfcat.rules
+++ b/etc/udev/rules.d/20-rfcat.rules
@@ -7,8 +7,6 @@ SUBSYSTEMS=="usb", ATTRS{idVendor}=="1d50", ATTRS{idProduct}=="6048", MODE:="066
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="1d50", ATTRS{idProduct}=="605b", MODE:="0660", SYMLINK+="RFCAT%n", GROUP="dialout"
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="1d50", ATTRS{idProduct}=="ecc1", MODE:="0660", SYMLINK+="RFCAT%n", GROUP="dialout"
 
-
-
 # RfCat bootloader subsystem (uses it's own product id)
 SUBSYSTEM=="tty", SUBSYSTEMS=="usb", ATTRS{idVendor}=="1d50", ATTRS{idProduct}=="6049", MODE:="0660", SYMLINK+="RFCAT_BL_C", ENV{ID_MM_DEVICE_IGNORE}="1", GROUP="dialout"
 SUBSYSTEM=="tty", SUBSYSTEMS=="usb", ATTRS{idVendor}=="1d50", ATTRS{idProduct}=="604a", MODE:="0660", SYMLINK+="RFCAT_BL_D", ENV{ID_MM_DEVICE_IGNORE}="1", GROUP="dialout"


### PR DESCRIPTION
ensure we're dealing with the tty subsystem when in bootloader mode, added commas to separate keys in udev rules