### PR TITLE
add `firmware/.revision` to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+firmware/.revision
 firmware/.serial
 firmware/*.asm
 firmware/*.ihx


### PR DESCRIPTION
now that revision.sh lives again, this file keeps trying to sneak into commits