### PR TITLE
Stage 2 of Porting Python 2 Code to Python 3

### DIFF
--- a/rflib/__init__.py
+++ b/rflib/__init__.py
@@ -3,6 +3,8 @@
 from __future__ import print_function
 from __future__ import absolute_import
 
+from builtins import str
+from builtins import range
 from .chipcon_nic import *
 import rflib.bits as rfbits
 
@@ -14,7 +16,7 @@ MAX_FREQ = 936e6
 class RfCat(FHSSNIC):
     def RFdump(self, msg="Receiving", maxnum=100, timeoutms=1000):
         try:
-            for x in xrange(maxnum):
+            for x in range(maxnum):
                 y, t = self.RFrecv(timeoutms)
                 print("(%5.3f) %s:  %s" % (t, msg, y.encode('hex')))
         except ChipconUsbTimeoutException:
@@ -31,7 +33,7 @@ class RfCat(FHSSNIC):
         while not keystop():
             try:
                 print("(press Enter to quit)")
-                for freq in xrange(int(basefreq), int(basefreq+(inc*count)), int(inc)):
+                for freq in range(int(basefreq), int(basefreq+(inc*count)), int(inc)):
                     print("Scanning for frequency %d..." % freq)
                     self.setFreq(freq)
                     self.RFdump(timeoutms=delaysec*1000)

--- a/rflib/bits.py
+++ b/rflib/bits.py
@@ -1,11 +1,16 @@
 from __future__ import print_function
+from __future__ import division
 
+from builtins import hex
+from builtins import chr
+from builtins import range
+from past.utils import old_div
 import struct
 
 fmtsLSB = [None, "B", "<H", "<I", "<I", "<Q", "<Q", "<Q", "<Q"]
 fmtsMSB = [None, "B", ">H", ">I", ">I", ">Q", ">Q", ">Q", ">Q"]
 sizes = [ 0, 1, 2, 4, 4, 8, 8, 8, 8]
-masks = [ (1<<(8*i))-1 for i in xrange(9) ]
+masks = [ (1<<(8*i))-1 for i in range(9) ]
 
 def wtfo(string):
     outstr = []
@@ -76,7 +81,7 @@ def bitReverse(num, bitcnt):
 def shiftString(string, bits):
     carry = 0
     news = []
-    for x in xrange(len(string)-1):
+    for x in range(len(string)-1):
         newc = ((ord(string[x]) << bits) + (ord(string[x+1]) >> (8-bits))) & 0xff
         news.append("%c"%newc)
     newc = (ord(string[-1])<<bits) & 0xff
@@ -125,7 +130,7 @@ def whitenData(data, seed=0xffff, getNextByte=getNextByte_feedbackRegister7bitsM
 
     carry = 0
     news = []
-    for x in xrange(len(data)-1):
+    for x in range(len(data)-1):
         newc = ((ord(data[x]) ^ getNextByte() ) & 0xff)
         news.append("%c"%newc)
     return "".join(news)
@@ -182,7 +187,7 @@ def findSyncWord(byts, sensitivity=4, minpreamble=2):
                 #print "bits: %x" % (bits1)
                 
                 bitcount = min( 2 * sensitivity, 17 ) 
-                for frontbits in xrange( bitcount ):            # with so many bit-inverted systems, let's not assume we know anything about the bit-arrangement.  \x55\x55 could be a perfectly reasonable preamble.
+                for frontbits in range( bitcount ):            # with so many bit-inverted systems, let's not assume we know anything about the bit-arrangement.  \x55\x55 could be a perfectly reasonable preamble.
                     poss = (bits1 >> frontbits) & 0xffff
                     if not poss in possDwords:
                         possDwords.append(poss)
@@ -229,7 +234,7 @@ def findSyncWordDoubled(byts):
             
 
             frontbits = 0
-            for frontbits in xrange(16, 40, 2):    #FIXME: if this doesn't work, try 16, then 18+frontbits
+            for frontbits in range(16, 40, 2):    #FIXME: if this doesn't work, try 16, then 18+frontbits
                 dwb1 = (bits1 >> (frontbits)) & 3
                 dwb2 = (bits2 >> (frontbits)) & 3
                 print("\tfrontbits: %d \t\t dwb1: %s dwb2: %s" % (frontbits, bin(bits1 >> (frontbits)), bin(bits2 >> (frontbits))))
@@ -237,7 +242,7 @@ def findSyncWordDoubled(byts):
                     break
 
             # frontbits now represents our unknowns...  let's go from the other side now
-            for tailbits in xrange(16, -1, -2):
+            for tailbits in range(16, -1, -2):
                 dwb1 = (bits1 >> (tailbits)) & 3
                 dwb2 = (bits2 >> (tailbits)) & 3
                 print("\ttailbits: %d\t\t dwb1: %s dwb2: %s" % (tailbits, bin(bits1 >> (tailbits)), bin(bits2 >> (tailbits))))
@@ -270,7 +275,7 @@ def visBits(data):
 
 
 def getBit(data, bit):
-    idx = bit / 8
+    idx = old_div(bit, 8)
     bidx = bit % 8
     char = data[idx]
     return (ord(char)>>(7-bidx)) & 1
@@ -357,7 +362,7 @@ def bitSectString(string, startbit, endbit):
     s = ''
     bit = startbit
 
-    Bidx = bit / 8
+    Bidx = old_div(bit, 8)
     bidx = (bit % 8)
 
     while bit < endbit:
@@ -385,7 +390,7 @@ def bitSectString(string, startbit, endbit):
 
         s += chr(byte)
     
-    ent = (min(entropy)+1.0) / (max(entropy)+1)
+    ent = old_div((min(entropy)+1.0), (max(entropy)+1))
     #print "entropy: %f" % ent
     return (s, ent)
 
@@ -451,9 +456,9 @@ def reprBitArray(bitAry, width=194):
     # top line
     #FIXME: UGGGGLY and kinda broken.
     fraction = 1.0 * arylen/width
-    expand = [bitAry[int(x*fraction)] for x in xrange(width)]
+    expand = [bitAry[int(x*fraction)] for x in range(width)]
 
-    for bindex in xrange(width):
+    for bindex in range(width):
         bits = 0
         if bindex>0:
             bits += (expand[bindex-1]) << (2)
@@ -488,7 +493,7 @@ def invertBits(data):
     #    output.append( struct.pack( "<I", struct.unpack( "<I", data[idx:idx+4] )[0] & 0xffff) )
 
     #method2
-    count = ldata / 4
+    count = old_div(ldata, 4)
     #print ldata, count
     numlist = struct.unpack( "<%dI" % count, data[off:] )
     modlist = [ struct.pack("<L", (x^0xffffffff) ) for x in numlist ]
@@ -658,7 +663,7 @@ def findManchester(data, minbytes=10):
             else:
                 # we're done, or not started
                 if lastCount >= minbits:
-                    lenbytes = (lastCount / 8)
+                    lenbytes = (old_div(lastCount, 8))
                     lenbits = lastCount % 8
                     startbyte = bidx - lenbytes
                     if lenbits > btidx:

--- a/rflib/bits.py
+++ b/rflib/bits.py
@@ -2,8 +2,8 @@ from __future__ import print_function
 from __future__ import division
 
 from builtins import hex
-from builtins import chr
 from builtins import range
+from builtins import bytes
 from past.utils import old_div
 import struct
 
@@ -43,7 +43,7 @@ def strBitReverse(string):
     # convert back from MSB number to string
     out = []
     for x in range(len(string)):
-        out.append(chr(rnum&0xff))
+        out.append(bytes([rnum&0xff]))
         rnum >>= 8
     out.reverse()
     print(''.join(out).encode('hex'))
@@ -388,7 +388,7 @@ def bitSectString(string, startbit, endbit):
             mask = ~ ( (1<<diff) - 1 )
             byte &= mask
 
-        s += chr(byte)
+        s += bytes([byte])
     
     ent = old_div((min(entropy)+1.0), (max(entropy)+1))
     #print "entropy: %f" % ent
@@ -481,7 +481,7 @@ def invertBits(data):
     off = 0
 
     if ldata&1:
-        output.append( chr( ord( data[0] ) ^ 0xff) )
+        output.append( bytes([ ord( data[0] ) ^ 0xff]) )
         off = 1
 
     if ldata&2:
@@ -546,12 +546,12 @@ def diff_manchester_decode(data, align=False):
 
             last = (bit0 << 1) | bit1
         if (bidx & 1): 
-            out.append(chr(obyte))
+            out.append(bytes([obyte]))
             obyte = 0
 
     if not (bidx & 1):
         obyte << 4 # pad 0's on end
-        out.append(chr(obyte))
+        out.append(bytes([obyte]))
     return ''.join(out)
 
 
@@ -573,12 +573,12 @@ def biphase_mark_coding_encode(data):
             last = bit
         if bidx & 1:
             print("%d - write" % bidx)
-            out.append(chr(obyte))
+            out.append(bytes([obyte]))
         else:
             print("%d - skip" % bidx)
     if not (bidx & 1):
         print("%d - write" % bidx)
-        out.append(chr(obyte))
+        out.append(bytes([obyte]))
 
     return ''.join(out)
 
@@ -602,12 +602,12 @@ def manchester_decode(data, hilo=1):
 
             last = bit
         if (bidx & 1): 
-            out.append(chr(obyte))
+            out.append(bytes([obyte]))
             obyte = 0
 
     if not (bidx & 1):
         obyte << 4 # pad 0's on end
-        out.append(chr(obyte))
+        out.append(bytes([obyte]))
     return ''.join(out)
 
 def manchester_encode(data, hilo=1):

--- a/rflib/cc111Xhparser.py
+++ b/rflib/cc111Xhparser.py
@@ -127,7 +127,7 @@ if __name__ == '__main__':
     defs.update(parseLines(file('../includes/cc1111.h')))
     defs.update(parseLines(file('/usr/share/sdcc/include/mcs51/cc1110.h')))
 
-    skeys = defs.keys()
+    skeys = list(defs.keys())
     skeys.sort()
     out = ["%-30s = %s"%(key,defs[key]) for key in skeys]
 

--- a/rflib/ccspecan.py
+++ b/rflib/ccspecan.py
@@ -32,7 +32,11 @@ import time
 import numpy
 import threading
 import rflib
-import pickle as pickle
+# import cPickle in Python 2 instead of pickle in Python 3
+if sys.version_info < (3,):
+    import cPickle as pickle
+else:
+    import pickle as pickle
 
 from PySide2 import QtCore, QtGui, QtWidgets
 from PySide2.QtCore import Qt, QPointF, QLineF

--- a/rflib/ccspecan.py
+++ b/rflib/ccspecan.py
@@ -24,7 +24,7 @@ from __future__ import division
 
 from future import standard_library
 standard_library.install_aliases()
-from builtins import chr
+from builtins import bytes
 from builtins import range
 from past.utils import old_div
 import sys
@@ -415,7 +415,7 @@ class Window(QtWidgets.QWidget):
 
         # anything else is alphanumeric
         try:
-            key= chr(event.key()).upper()
+            key= bytes([event.key()]).upper()
             event.accept()
         except:
             print('Unknown key pressed: 0x%x' % event.key())

--- a/rflib/ccspecan.py
+++ b/rflib/ccspecan.py
@@ -20,13 +20,19 @@
 # Boston, MA 02110-1301, USA.
 
 from __future__ import print_function
+from __future__ import division
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import chr
+from builtins import range
+from past.utils import old_div
 import sys
 import time
 import numpy
 import threading
 import rflib
-import cPickle as pickle
+import pickle as pickle
 
 from PySide2 import QtCore, QtGui, QtWidgets
 from PySide2.QtCore import Qt, QPointF, QLineF
@@ -59,11 +65,11 @@ class SpecanThread(threading.Thread):
         # this is where we pull in the data from the device
         #frame_source = self._device.specan(self._low_frequency, self._high_frequency)
 
-        num_chans = int((self._high_frequency - self._low_frequency) / self._freq_step)
+        num_chans = int(old_div((self._high_frequency - self._low_frequency), self._freq_step))
         
         if type(self._data) == list:
             for rssi_values, timestamp in self._data:
-                rssi_values = [ ((ord(x)^0x80)/2)-88 for x in rssi_values[4:] ]
+                rssi_values = [ (old_div((ord(x)^0x80),2))-88 for x in rssi_values[4:] ]
                 # since we are not accessing the dongle, we need some sort of delay
                 time.sleep(self._delay)
                 frequency_axis = numpy.linspace(self._low_frequency, self._high_frequency, num=len(rssi_values), endpoint=True)
@@ -75,7 +81,7 @@ class SpecanThread(threading.Thread):
             while not self._stop:
                 try:
                     rssi_values, timestamp = self._data.recv(APP_SPECAN, SPECAN_QUEUE, 10000)
-                    rssi_values = [ ((ord(x)^0x80)/2)-88 for x in rssi_values ]
+                    rssi_values = [ (old_div((ord(x)^0x80),2))-88 for x in rssi_values ]
                     frequency_axis = numpy.linspace(self._low_frequency, self._high_frequency, num=len(rssi_values), endpoint=True)
 
                     self._new_frame_callback(numpy.copy(frequency_axis), numpy.copy(rssi_values))
@@ -139,7 +145,7 @@ class RenderArea(QtWidgets.QWidget):
         self._persisted_frames_next_index = 0
     
     def minimumSizeHint(self):
-        x_points = round((self._high_frequency - self._low_frequency) / self._frequency_step)
+        x_points = round(old_div((self._high_frequency - self._low_frequency), self._frequency_step))
         y_points = round(self._high_dbm - self._low_dbm)
         return QtCore.QSize(x_points * 4, y_points * 1)
     
@@ -171,7 +177,7 @@ class RenderArea(QtWidgets.QWidget):
                 path_now = QtGui.QPainterPath()
                 path_max = QtGui.QPainterPath()
                 
-                bins = range(len(frequency_axis))
+                bins = list(range(len(frequency_axis)))
                 x_axis = self._hz_to_x(frequency_axis)
                 y_now = self._dbm_to_y(rssi_values)
                 y_max = self._dbm_to_y(numpy.amax(self._persisted_frames, axis=0))
@@ -200,32 +206,32 @@ class RenderArea(QtWidgets.QWidget):
                     pen.setBrush(Qt.red)
                     pen.setStyle(Qt.DotLine)
                     painter.setPen(pen)
-                    painter.drawText(QPointF(x_axis[max_max] + 4, 30), '%.06f' % (self._x_to_hz(x_axis[max_max]) / 1e6))
+                    painter.drawText(QPointF(x_axis[max_max] + 4, 30), '%.06f' % (old_div(self._x_to_hz(x_axis[max_max]), 1e6)))
                     painter.drawText(QPointF(30, y_max[max_max] - 4), '%d' % (self._y_to_dbm(y_max[max_max])))
                     painter.drawLine(QPointF(x_axis[max_max], 0), QPointF(x_axis[max_max], self.height()))
                     painter.drawLine(QPointF(0, y_max[max_max]), QPointF(self.width(), y_max[max_max]))
                     if self._mouse_x:
-                        painter.drawText(QPointF(self._hz_to_x(self._mouse_x) + 4, 58), '(%.06f)' % ((self._x_to_hz(x_axis[max_max]) / 1e6) - (self._mouse_x / 1e6)))
+                        painter.drawText(QPointF(self._hz_to_x(self._mouse_x) + 4, 58), '(%.06f)' % ((old_div(self._x_to_hz(x_axis[max_max]), 1e6)) - (old_div(self._mouse_x, 1e6))))
                         pen.setBrush(Qt.yellow)
                         painter.setPen(pen)
-                        painter.drawText(QPointF(self._hz_to_x(self._mouse_x) + 4, 44), '%.06f' % (self._mouse_x / 1e6))
+                        painter.drawText(QPointF(self._hz_to_x(self._mouse_x) + 4, 44), '%.06f' % (old_div(self._mouse_x, 1e6)))
                         painter.drawText(QPointF(54, self._dbm_to_y(self._mouse_y) - 4), '%d' % (self._mouse_y))
                         painter.drawLine(QPointF(self._hz_to_x(self._mouse_x), 0), QPointF(self._hz_to_x(self._mouse_x), self.height()))
                         painter.drawLine(QPointF(0, self._dbm_to_y(self._mouse_y)), QPointF(self.width(), self._dbm_to_y(self._mouse_y)))
                         if self._mouse_x2:
-                            painter.drawText(QPointF(self._hz_to_x(self._mouse_x2) + 4, 118), '(%.06f)' % ((self._mouse_x / 1e6) - (self._mouse_x2 / 1e6)))
+                            painter.drawText(QPointF(self._hz_to_x(self._mouse_x2) + 4, 118), '(%.06f)' % ((old_div(self._mouse_x, 1e6)) - (old_div(self._mouse_x2, 1e6))))
                     if self._mouse_x2:
                         pen.setBrush(Qt.red)
                         painter.setPen(pen)
-                        painter.drawText(QPointF(self._hz_to_x(self._mouse_x2) + 4, 102), '(%.06f)' % ((self._x_to_hz(x_axis[max_max]) / 1e6) - (self._mouse_x2 / 1e6)))
+                        painter.drawText(QPointF(self._hz_to_x(self._mouse_x2) + 4, 102), '(%.06f)' % ((old_div(self._x_to_hz(x_axis[max_max]), 1e6)) - (old_div(self._mouse_x2, 1e6))))
                         pen.setBrush(Qt.magenta)
                         painter.setPen(pen)
-                        painter.drawText(QPointF(self._hz_to_x(self._mouse_x2) + 4, 88), '%.06f' % (self._mouse_x2 / 1e6))
+                        painter.drawText(QPointF(self._hz_to_x(self._mouse_x2) + 4, 88), '%.06f' % (old_div(self._mouse_x2, 1e6)))
                         painter.drawText(QPointF(78, self._dbm_to_y(self._mouse_y2) - 4), '%d' % (self._mouse_y2))
                         painter.drawLine(QPointF(self._hz_to_x(self._mouse_x2), 0), QPointF(self._hz_to_x(self._mouse_x2), self.height()))
                         painter.drawLine(QPointF(0, self._dbm_to_y(self._mouse_y2)), QPointF(self.width(), self._dbm_to_y(self._mouse_y2)))
                         if self._mouse_x:
-                            painter.drawText(QPointF(self._hz_to_x(self._mouse_x) + 4, 74), '(%.06f)' % ((self._mouse_x2 / 1e6) - (self._mouse_x / 1e6)))
+                            painter.drawText(QPointF(self._hz_to_x(self._mouse_x) + 4, 74), '(%.06f)' % ((old_div(self._mouse_x2, 1e6)) - (old_div(self._mouse_x, 1e6))))
         finally:
             painter.end()
             
@@ -262,7 +268,7 @@ class RenderArea(QtWidgets.QWidget):
                 for dbm, point in dbm_labels:
                     painter.drawText(point, '%+.0f' % dbm)
                 for frequency, point in frequency_labels:
-                    painter.drawText(point, '%.02f' % (frequency / 1e6))
+                    painter.drawText(point, '%.02f' % (old_div(frequency, 1e6)))
                     
             finally:
                 painter.end()
@@ -293,25 +299,25 @@ class RenderArea(QtWidgets.QWidget):
     def _hz_to_x(self, frequency_hz):
         delta = frequency_hz - self._low_frequency
         range = self._high_frequency - self._low_frequency
-        normalized = delta / range
+        normalized = old_div(delta, range)
         #print "freq: %s \nlow: %s \nhigh: %s \ndelta: %s \nrange: %s \nnormalized: %s" % (frequency_hz, self._low_frequency, self._high_frequency, delta, range, normalized)
         return normalized * self.width()
 
     def _x_to_hz(self, x):
         range = self._high_frequency - self._low_frequency
-        tmp = x / self.width()
+        tmp = old_div(x, self.width())
         delta = tmp * range
         return delta + self._low_frequency
                              
     def _dbm_to_y(self, dbm):
         delta = self._high_dbm - dbm
         range = self._high_dbm - self._low_dbm
-        normalized = delta / range
+        normalized = old_div(delta, range)
         return normalized * self.height()
 
     def _y_to_dbm(self, y):
         range = self._high_dbm - self._low_dbm
-        tmp = y / self.height()
+        tmp = old_div(y, self.height())
         delta = tmp * range
         return self._high_dbm - delta
 
@@ -345,7 +351,7 @@ class Window(QtWidgets.QWidget):
                 data._debug = 1
                 freq = int(self._low_freq)
                 spc = int(self._spacing)
-                numChans = int((self._high_freq-self._low_freq) / self._spacing)
+                numChans = int(old_div((self._high_freq-self._low_freq), self._spacing))
                 data._doSpecAn(freq, spc, numChans)
             else:
                 data = pickle.load(file(data,'rb'))

--- a/rflib/chipcon_nic.py
+++ b/rflib/chipcon_nic.py
@@ -4,7 +4,7 @@ from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
 
-from builtins import chr
+from builtins import bytes
 from builtins import hex
 from builtins import range
 from builtins import object
@@ -443,14 +443,14 @@ class NICxx11(USBDongle):
             if 'suppress' the radio state (RX/TX/IDLE) is not modified
         '''
         if suppress:
-            self.poke(regaddr, chr(value))
+            self.poke(regaddr, bytes([value]))
             return
             
         marcstate = self.radiocfg.marcstate
         if marcstate != MARC_STATE_IDLE:
             self.strobeModeIDLE()
             
-        self.poke(regaddr, chr(value))
+        self.poke(regaddr, bytes([value]))
         
         self.strobeModeReturn(marcstate)
         #if (marcstate == MARC_STATE_RX):
@@ -1303,7 +1303,7 @@ class NICxx11(USBDongle):
         return self.send(APP_NIC, NIC_GET_AMP_MODE, "")
 
     def setPktAddr(self, addr):
-        return self.poke(ADDR, chr(addr))
+        return self.poke(ADDR, bytes([addr]))
 
     def getPktAddr(self):
         return self.peek(ADDR)
@@ -2035,9 +2035,9 @@ class FHSSNIC(NICxx11):
         t2ctl = (ord(self.peek(X_T2CTL)) & 0xfc)   | (tipidx)
         clkcon = (ord(self.peek(X_CLKCON)) & 0xc7) | (tickidx<<3)
         
-        self.poke(X_T2PR, chr(PR))
-        self.poke(X_T2CTL, chr(t2ctl))
-        self.poke(X_CLKCON, chr(clkcon))
+        self.poke(X_T2PR, bytes([PR]))
+        self.poke(X_T2CTL, bytes([t2ctl]))
+        self.poke(X_CLKCON, bytes([clkcon]))
 
     def _setMACmode(self, _mode):
         '''

--- a/rflib/chipcon_nic.py
+++ b/rflib/chipcon_nic.py
@@ -2,7 +2,13 @@
 
 from __future__ import print_function
 from __future__ import absolute_import
+from __future__ import division
 
+from builtins import chr
+from builtins import hex
+from builtins import range
+from builtins import object
+from past.utils import old_div
 import re
 import sys
 import usb
@@ -92,7 +98,7 @@ FHSS_LAST_STATE =               5       # used for testing
 
 
 FHSS_STATES = {}
-for key,val in globals().items():
+for key,val in list(globals().items()):
     if key.startswith("FHSS_STATE_"):
         FHSS_STATES[key] = val
         FHSS_STATES[val] = key
@@ -225,7 +231,7 @@ def makeFriendlyAscii(instring):
     last = -1
     instrlen = len(instring)
 
-    for cidx in xrange(instrlen):
+    for cidx in range(instrlen):
         if (0x20 < ord(instring[cidx]) < 0x7f):
             if last < cidx-1:
                 out.append( "." * (cidx-1-last))
@@ -247,13 +253,13 @@ def makeFriendlyAscii(instring):
 
 def calculateT2(tick_ms, mhz=24):
     # each tick, not each cycle
-    TICKSPD = [(mhz*1000000/pow(2,x)) for x in range(8)]
+    TICKSPD = [(old_div(mhz*1000000,pow(2,x))) for x in range(8)]
     
     tick_ms = 1.0*tick_ms/1000
     candidates = []
-    for tickidx in xrange(8):
+    for tickidx in range(8):
         for tipidx in range(4):
-            for PR in xrange(256):
+            for PR in range(256):
                 T = 1.0 * PR * TIP[tipidx] / TICKSPD[tickidx]
                 if abs(T-tick_ms) < .010:
                     candidates.append((T, tickidx, tipidx, PR))
@@ -267,7 +273,7 @@ def calculateT2(tick_ms, mhz=24):
     #return ms, candidates, best
             
 
-class EnDeCode:
+class EnDeCode(object):
     def encode(self, msg):
         raise Exception("EnDeCode.encode() not implemented.  Each subclass must implement their own")
     def decode(self, msg):
@@ -283,7 +289,7 @@ def printSyncWords(syncworddict):
     print("SyncWords seen:")
 
     tmp = []
-    for x,y in syncworddict.items():
+    for x,y in list(syncworddict.items()):
         tmp.append((y,x))
     tmp.sort()
     for y,x in tmp:
@@ -497,7 +503,7 @@ class NICxx11(USBDongle):
         else:
             applyConfig = False
 
-        freqmult = (0x10000 / 1000000.0) / mhz
+        freqmult = old_div((0x10000 / 1000000.0), mhz)
         num = int(freq * freqmult)
         radiocfg.freq2 = num >> 16
         radiocfg.freq1 = (num>>8) & 0xff
@@ -524,13 +530,13 @@ class NICxx11(USBDongle):
                 #self.strobeModeTX()
 
     def getFreq(self, mhz=24, radiocfg=None):
-        freqmult = (0x10000 / 1000000.0) / mhz
+        freqmult = old_div((0x10000 / 1000000.0), mhz)
         if radiocfg==None:
             self.getRadioConfig()
             radiocfg = self.radiocfg
             
         num = (radiocfg.freq2<<16) + (radiocfg.freq1<<8) + radiocfg.freq0
-        freq = num / freqmult
+        freq = old_div(num, freqmult)
         return freq, hex(num)
 
     def getFreqEst(self, radiocfg=None):
@@ -656,7 +662,7 @@ class NICxx11(USBDongle):
 
         if (chanspc != None):
             for e in range(4):
-                m = int(((chanspc * pow(2,18) / (1000000.0 * mhz * pow(2,e)))-256) +.5)    # rounded evenly
+                m = int(((old_div(chanspc * pow(2,18), (1000000.0 * mhz * pow(2,e))))-256) +.5)    # rounded evenly
                 if m < 256:
                     chanspc_e = e
                     chanspc_m = m
@@ -858,7 +864,7 @@ class NICxx11(USBDongle):
             self.getRadioConfig()
             radiocfg = self.radiocfg
 
-        ifBits = freq_if * pow(2,10) / (1000000.0 * mhz)
+        ifBits = old_div(freq_if * pow(2,10), (1000000.0 * mhz))
         ifBits = int(ifBits + .5)       # rounded evenly
 
         if ifBits >0x1f:
@@ -955,7 +961,7 @@ class NICxx11(USBDongle):
         chanbw_e = None
         chanbw_m = None
         for e in range(4):
-            m = int(((mhz*1000000.0 / (bw *pow(2,e) * 8.0 )) - 4) + .5)        # rounded evenly
+            m = int(((old_div(mhz*1000000.0, (bw *pow(2,e) * 8.0 ))) - 4) + .5)        # rounded evenly
             if m < 4:
                 chanbw_e = e
                 chanbw_m = m
@@ -1005,7 +1011,7 @@ class NICxx11(USBDongle):
         drate_e = None
         drate_m = None
         for e in range(16):
-            m = int((drate * pow(2,28) / (pow(2,e)* (mhz*1000000.0))-256) + .5)        # rounded evenly
+            m = int((old_div(drate * pow(2,28), (pow(2,e)* (mhz*1000000.0)))-256) + .5)        # rounded evenly
             if m < 256:
                 drate_e = e
                 drate_m = m
@@ -1049,7 +1055,7 @@ class NICxx11(USBDongle):
         dev_e = None
         dev_m = None
         for e in range(8):
-            m = int((deviatn * pow(2,17) / (pow(2,e)* (mhz*1000000.0))-8) + .5)        # rounded evenly
+            m = int((old_div(deviatn * pow(2,17), (pow(2,e)* (mhz*1000000.0)))-8) + .5)        # rounded evenly
             if m < 8:
                 dev_e = e
                 dev_m = m
@@ -1165,9 +1171,9 @@ class NICxx11(USBDongle):
         if baud <= 2400:
             deviatn = 5100
         elif baud <= 38400:
-            deviatn = 20000 * ((baud-2400)/36000)
+            deviatn = 20000 * (old_div((baud-2400),36000))
         else:
-            deviatn = 129000 * ((baud-38400)/211600)
+            deviatn = 129000 * (old_div((baud-38400),211600))
         self.setMdmDeviatn(deviatn)
 
     def calculatePktChanBW(self, mhz=24, radiocfg=None):
@@ -1320,7 +1326,7 @@ class NICxx11(USBDongle):
         # calculate wait time
         waitlen = len(data)
         waitlen += repeat * (len(data) - offset)
-        wait = USB_TX_WAIT * ((waitlen / RF_MAX_TX_BLOCK) + 1)
+        wait = USB_TX_WAIT * ((old_div(waitlen, RF_MAX_TX_BLOCK)) + 1)
         self.send(APP_NIC, NIC_XMIT, "%s" % struct.pack("<HHH",len(data),repeat,offset)+data, wait=wait)
 
     def RFxmitLong(self, data, doencoding=True):
@@ -1335,17 +1341,17 @@ class NICxx11(USBDongle):
 
         # calculate wait time
         waitlen = len(data)
-        wait = USB_TX_WAIT * ((waitlen / RF_MAX_TX_BLOCK) + 1)
+        wait = USB_TX_WAIT * ((old_div(waitlen, RF_MAX_TX_BLOCK)) + 1)
 
 
         # load chunk buffers
         chunks = []
-        for x in range(datalen / RF_MAX_TX_CHUNK):
+        for x in range(old_div(datalen, RF_MAX_TX_CHUNK)):
             chunks.append(data[x * RF_MAX_TX_CHUNK:(x + 1) * RF_MAX_TX_CHUNK])
         if datalen % RF_MAX_TX_CHUNK:
             chunks.append(data[-(datalen % RF_MAX_TX_CHUNK):])
 
-        preload = RF_MAX_TX_BLOCK / RF_MAX_TX_CHUNK
+        preload = old_div(RF_MAX_TX_BLOCK, RF_MAX_TX_CHUNK)
         retval, ts = self.send(APP_NIC, NIC_XMIT_LONG, "%s" % struct.pack("<HB",datalen,preload)+data[:RF_MAX_TX_CHUNK * preload], wait=wait*preload)
         #sys.stderr.write('=' + repr(retval))
         error = struct.unpack("<B", retval[0])[0]
@@ -2022,7 +2028,7 @@ class FHSSNIC(NICxx11):
         macdata = self.getMACdata()
         cycles_per_channel = macdata[1]
         ticks_per_cycle = 256
-        tick_ms = dwell_ms / (ticks_per_cycle * cycles_per_channel)
+        tick_ms = old_div(dwell_ms, (ticks_per_cycle * cycles_per_channel))
         val = calculateT2(tick_ms, mhz)
         T, tickidx, tipidx, PR = val
         print("Setting MAC period to %f secs (%x %x %x)" % (val))
@@ -2284,7 +2290,7 @@ def getValueFromReprString(stringarray, line_text):
             return (string,val)
 
 def mkFreq(freq=902000000, mhz=24):
-    freqmult = (0x10000 / 1000000.0) / mhz
+    freqmult = old_div((0x10000 / 1000000.0), mhz)
     num = int(freq * freqmult)
     freq2 = num >> 16
     freq1 = (num>>8) & 0xff

--- a/rflib/chipcon_usb.py
+++ b/rflib/chipcon_usb.py
@@ -4,7 +4,7 @@ from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
 
-from builtins import chr
+from builtins import bytes
 from builtins import str
 from builtins import hex
 from builtins import range
@@ -957,7 +957,7 @@ def unittest(self, mhz=24):
     print(repr(self.peek(0xf000, 400)))
 
     print("\nTesting USB poke/peek")
-    data = "".join([chr(c) for c in range(120)])
+    data = "".join([bytes([c]) for c in range(120)])
     where = 0xf300
     self.poke(where, data)
     ndata = self.peek(where, len(data))

--- a/rflib/chipcon_usb.py
+++ b/rflib/chipcon_usb.py
@@ -2,7 +2,14 @@
 
 from __future__ import print_function
 from __future__ import absolute_import
+from __future__ import division
 
+from builtins import chr
+from builtins import str
+from builtins import hex
+from builtins import range
+from builtins import object
+from past.utils import old_div
 import os
 import sys
 import usb
@@ -117,7 +124,7 @@ RCS = {}
 LCS = {}
 LCES = {}
 lcls = locals()
-for lcl in lcls.keys():
+for lcl in list(lcls.keys()):
     if lcl.startswith("LCE_"):
         LCES[lcl] = lcls[lcl]
         LCES[lcls[lcl]] = lcl
@@ -166,7 +173,7 @@ class ChipconUsbTimeoutException(Exception):
 
 direct=False
 
-class USBDongle:
+class USBDongle(object):
     ######## INITIALIZATION ########
     def __init__(self, idx=0, debug=False, copyDongle=None, RfMode=RFST_SRX):
         self.rsema = None
@@ -375,7 +382,7 @@ class USBDongle:
         if self._debug:
             print(("_clear_buffers()"), file=sys.stderr)
         if clear_recv_mbox:
-            for key in self.recv_mbox.keys():
+            for key in list(self.recv_mbox.keys()):
                 self.trash.extend(self.recvAll(key))
         elif self.recv_mbox.get(APP_SYSTEM) != None:
             self.trash.extend(self.recvAll(APP_SYSTEM))
@@ -432,7 +439,7 @@ class USBDongle:
                 q = None
                 b = self.recv_mbox.get(APP_DEBUG, None)
                 if (b != None):
-                    for cmd in b.keys():
+                    for cmd in list(b.keys()):
                         q = b[cmd]
                         if len(q):
                             buf,timestamp = q.pop(0)
@@ -629,9 +636,9 @@ class USBDongle:
                 if b:
                     if self._debug: print("Recv msg",app,b,cmd, file=sys.stderr)
                     if cmd is None:
-                        keys = b.keys()
+                        keys = list(b.keys())
                         if len(keys):
-                            cmd = b.keys()[-1] # just grab one.   no guarantees on the order
+                            cmd = list(b.keys())[-1] # just grab one.   no guarantees on the order
 
                 if b is not None and cmd is not None:
                     q = b.get(cmd)
@@ -657,7 +664,7 @@ class USBDongle:
 
                         self.rsema.release()
 
-                self.recv_event.wait((wait - (time.time() - startTime)*1000)/1000) # wait on recv event, with timeout of remaining time
+                self.recv_event.wait(old_div((wait - (time.time() - startTime)*1000),1000)) # wait on recv event, with timeout of remaining time
                 self.recv_event.clear() # clear event, if it's set
 
             except KeyboardInterrupt:
@@ -922,11 +929,11 @@ class USBDongle:
         output.append('     client errored cycles:     %d' % self._usberrorcnt)
         output.append('     recv_queue:                (%d bytes) %s'%(len(self.recv_queue),repr(self.recv_queue)[:width-42]))
         output.append('     trash:                     (%d blobs) "%s"'%(len(self.trash),repr(self.trash)[:width-44]))
-        output.append('     recv_mbox                  (%d keys)  "%s"'%(len(self.recv_mbox),repr([hex(x) for x in self.recv_mbox.keys()])[:width-44]))
-        for app in self.recv_mbox.keys():
+        output.append('     recv_mbox                  (%d keys)  "%s"'%(len(self.recv_mbox),repr([hex(x) for x in list(self.recv_mbox.keys())])[:width-44]))
+        for app in list(self.recv_mbox.keys()):
             appbox = self.recv_mbox[app]
             output.append('       app 0x%x (%d records)'%(app,len(appbox)))
-            for cmd in appbox.keys():
+            for cmd in list(appbox.keys()):
                 output.append('             [0x%x]    (%d frames)  "%s"'%(cmd, len(appbox[cmd]), repr(appbox[cmd])[:width-36]))
             output.append('')
         return "\n".join(output)
@@ -950,7 +957,7 @@ def unittest(self, mhz=24):
     print(repr(self.peek(0xf000, 400)))
 
     print("\nTesting USB poke/peek")
-    data = "".join([chr(c) for c in xrange(120)])
+    data = "".join([chr(c) for c in range(120)])
     where = 0xf300
     self.poke(where, data)
     ndata = self.peek(where, len(data))

--- a/rflib/chipcondefs.py
+++ b/rflib/chipcondefs.py
@@ -1464,7 +1464,7 @@ PKTCTRL1S = {}
 RFIFS = {}
 RFIMS = {}
 
-for key,val in globals().items():
+for key,val in list(globals().items()):
     if key.startswith("RFIF_"):
         RFIFS[val] = key
     elif key.startswith("RFIM_"):

--- a/rflib/intelhex.py
+++ b/rflib/intelhex.py
@@ -52,6 +52,14 @@ from array import array
 from binascii import hexlify, unhexlify
 from bisect import bisect_right
 import os
+import sys
+
+
+# the Python 2 integer types int and long have been unified in Python 3
+if sys.version_info < (3,):
+    integer_types = (int, long,)
+else:
+    integer_types = (int,)
 
 
 class IntelHex(object):
@@ -264,7 +272,7 @@ class IntelHex(object):
         if 'start_addr' in s:
             del s['start_addr']
         for k in list(s.keys()):
-            if type(k) not in (int, int) or k < 0:
+            if type(k) not in integer_types or k < 0:
                 raise ValueError('Source dictionary should have only int keys')
         self._buf.update(s)
         if start_addr is not None:
@@ -381,7 +389,7 @@ class IntelHex(object):
                         if no data found.
         '''
         t = type(addr)
-        if t in (int, int):
+        if t in integer_types:
             if addr < 0:
                 raise TypeError('Address should be >= 0.')
             return self._buf.get(addr, self.padding)
@@ -404,7 +412,7 @@ class IntelHex(object):
     def __setitem__(self, addr, byte):
         """Set byte at address."""
         t = type(addr)
-        if t in (int, int):
+        if t in integer_types:
             if addr < 0:
                 raise TypeError('Address should be >= 0.')
             self._buf[addr] = byte
@@ -440,7 +448,7 @@ class IntelHex(object):
     def __delitem__(self, addr):
         """Delete byte at address."""
         t = type(addr)
-        if t in (int, int):
+        if t in integer_types:
             if addr < 0:
                 raise TypeError('Address should be >= 0.')
             del self._buf[addr]

--- a/rflib/intelhex.py
+++ b/rflib/intelhex.py
@@ -36,7 +36,14 @@
 @author     Alexander Belchenko (bialix AT ukr net)
 @version    1.1
 '''
+from __future__ import division
 
+from builtins import str
+from builtins import chr
+from builtins import range
+from past.builtins import basestring
+from builtins import object
+from past.utils import old_div
 __docformat__ = "javadoc"
 
 from __future__ import print_function
@@ -123,7 +130,7 @@ class IntelHex(object):
         if record_type == 0:
             # data record
             addr += self._offset
-            for i in xrange(4, 4+record_length):
+            for i in range(4, 4+record_length):
                 if not self._buf.get(addr, None) is None:
                     raise AddressOverlapError(address=addr, line=line)
                 self._buf[addr] = bin[i]
@@ -256,8 +263,8 @@ class IntelHex(object):
         start_addr = s.get('start_addr')
         if 'start_addr' in s:
             del s['start_addr']
-        for k in s.keys():
-            if type(k) not in (int, long) or k < 0:
+        for k in list(s.keys()):
+            if type(k) not in (int, int) or k < 0:
                 raise ValueError('Source dictionary should have only int keys')
         self._buf.update(s)
         if start_addr is not None:
@@ -293,7 +300,7 @@ class IntelHex(object):
 
         start, end = self._get_start_end(start, end)
 
-        for i in xrange(start, end+1):
+        for i in range(start, end+1):
             bin.append(self._buf.get(i, pad))
 
         return bin
@@ -343,7 +350,7 @@ class IntelHex(object):
         '''Returns all used addresses in sorted order.
         @return         list of occupied data addresses in sorted order. 
         '''
-        aa = self._buf.keys()
+        aa = list(self._buf.keys())
         aa.sort()
         return aa
 
@@ -351,7 +358,7 @@ class IntelHex(object):
         '''Get minimal address of HEX content.
         @return         minimal address or None if no data
         '''
-        aa = self._buf.keys()
+        aa = list(self._buf.keys())
         if aa == []:
             return None
         else:
@@ -361,7 +368,7 @@ class IntelHex(object):
         '''Get maximal address of HEX content.
         @return         maximal address or None if no data
         '''
-        aa = self._buf.keys()
+        aa = list(self._buf.keys())
         if aa == []:
             return None
         else:
@@ -374,19 +381,19 @@ class IntelHex(object):
                         if no data found.
         '''
         t = type(addr)
-        if t in (int, long):
+        if t in (int, int):
             if addr < 0:
                 raise TypeError('Address should be >= 0.')
             return self._buf.get(addr, self.padding)
         elif t == slice:
-            addresses = self._buf.keys()
+            addresses = list(self._buf.keys())
             ih = IntelHex()
             if addresses:
                 addresses.sort()
                 start = addr.start or addresses[0]
                 stop = addr.stop or (addresses[-1]+1)
                 step = addr.step or 1
-                for i in xrange(start, stop, step):
+                for i in range(start, stop, step):
                     x = self._buf.get(i)
                     if x is not None:
                         ih[i] = x
@@ -397,19 +404,19 @@ class IntelHex(object):
     def __setitem__(self, addr, byte):
         """Set byte at address."""
         t = type(addr)
-        if t in (int, long):
+        if t in (int, int):
             if addr < 0:
                 raise TypeError('Address should be >= 0.')
             self._buf[addr] = byte
         elif t == slice:
-            addresses = self._buf.keys()
+            addresses = list(self._buf.keys())
             if not isinstance(byte, (list, tuple)):
                 raise ValueError('Slice operation expects sequence of bytes')
             start = addr.start
             stop = addr.stop
             step = addr.step or 1
             if None not in (start, stop):
-                ra = range(start, stop, step)
+                ra = list(range(start, stop, step))
                 if len(ra) != len(byte):
                     raise ValueError('Length of bytes sequence does not match '
                         'address range')
@@ -424,7 +431,7 @@ class IntelHex(object):
             if stop < 0:
                 raise TypeError('stop address cannot be negative')
             j = 0
-            for i in xrange(start, stop, step):
+            for i in range(start, stop, step):
                 self._buf[i] = byte[j]
                 j += 1
         else:
@@ -433,18 +440,18 @@ class IntelHex(object):
     def __delitem__(self, addr):
         """Delete byte at address."""
         t = type(addr)
-        if t in (int, long):
+        if t in (int, int):
             if addr < 0:
                 raise TypeError('Address should be >= 0.')
             del self._buf[addr]
         elif t == slice:
-            addresses = self._buf.keys()
+            addresses = list(self._buf.keys())
             if addresses:
                 addresses.sort()
                 start = addr.start or addresses[0]
                 stop = addr.stop or (addresses[-1]+1)
                 step = addr.step or 1
-                for i in xrange(start, stop, step):
+                for i in range(start, stop, step):
                     x = self._buf.get(i)
                     if x is not None:
                         del self._buf[i]
@@ -453,7 +460,7 @@ class IntelHex(object):
 
     def __len__(self):
         """Return count of bytes with real values."""
-        return len(self._buf.keys())
+        return len(list(self._buf.keys()))
 
     def write_hex_file(self, f, write_start_addr=True):
         """Write data to file f in HEX format.
@@ -481,7 +488,7 @@ class IntelHex(object):
 
         # start address record if any
         if self.start_addr and write_start_addr:
-            keys = self.start_addr.keys()
+            keys = list(self.start_addr.keys())
             keys.sort()
             bin = array('B', '\0'*9)
             if keys == ['CS','IP']:
@@ -517,7 +524,7 @@ class IntelHex(object):
                 raise InvalidStartAddressValueError(start_addr=self.start_addr)
 
         # data
-        addresses = self._buf.keys()
+        addresses = list(self._buf.keys())
         addresses.sort()
         addr_len = len(addresses)
         if addr_len:
@@ -540,7 +547,7 @@ class IntelHex(object):
                     bin[1] = 0      # offset msb
                     bin[2] = 0      # offset lsb
                     bin[3] = 4      # rectyp
-                    high_ofs = int(cur_addr/65536)
+                    high_ofs = int(old_div(cur_addr,65536))
                     bytes = divmod(high_ofs, 256)
                     bin[4] = bytes[0]   # msb of high_ofs
                     bin[5] = bytes[1]   # lsb of high_ofs
@@ -590,7 +597,7 @@ class IntelHex(object):
                     else:
                         cur_addr = maxaddr + 1
                         break
-                    high_addr = int(cur_addr/65536)
+                    high_addr = int(old_div(cur_addr,65536))
                     if high_addr > high_ofs:
                         break
 
@@ -619,7 +626,7 @@ class IntelHex(object):
         be raised. Padding is not used."""
         a = array('B', '\0'*length)
         try:
-            for i in xrange(length):
+            for i in range(length):
                 a[i] = self._buf[addr+i]
         except KeyError:
             raise NotEnoughDataError(address=addr, length=length)
@@ -630,7 +637,7 @@ class IntelHex(object):
         entries.
         """
         a = array('B', s)
-        for i in xrange(len(s)):
+        for i in range(len(s)):
             self._buf[addr+i] = a[i]
 
     def getsz(self, addr):
@@ -676,17 +683,17 @@ class IntelHex(object):
             else:
                 tofile.write('start_addr = %r\n' % start_addr)
         # actual data
-        addresses = self._buf.keys()
+        addresses = list(self._buf.keys())
         if addresses:
             addresses.sort()
             minaddr = addresses[0]
             maxaddr = addresses[-1]
-            startaddr = int(minaddr/16)*16
-            endaddr = int(maxaddr/16+1)*16
+            startaddr = int(old_div(minaddr,16))*16
+            endaddr = int(old_div(maxaddr,16)+1)*16
             maxdigits = max(len(str(endaddr)), 4)
             templa = '%%0%dX' % maxdigits
-            range16 = range(16)
-            for i in xrange(startaddr, endaddr, 16):
+            range16 = list(range(16))
+            for i in range(startaddr, endaddr, 16):
                 tofile.write(templa % i)
                 tofile.write(' ')
                 s = []
@@ -814,22 +821,22 @@ class IntelHex16bit(IntelHex):
 
         @return         minimal address used in this object 
         '''
-        aa = self._buf.keys()
+        aa = list(self._buf.keys())
         if aa == []:
             return 0
         else:
-            return min(aa)/2
+            return old_div(min(aa),2)
 
     def maxaddr(self):
         '''Get maximal address of HEX content in 16-bit mode.
 
         @return         maximal address used in this object 
         '''
-        aa = self._buf.keys()
+        aa = list(self._buf.keys())
         if aa == []:
             return 0
         else:
-            return max(aa)/2
+            return old_div(max(aa),2)
 
 #/class IntelHex16bit
 
@@ -1054,7 +1061,7 @@ class IntelHexError(Exception):
         """Initialize the Exception with the given message.
         """
         self.msg = msg
-        for key, value in kw.items():
+        for key, value in list(kw.items()):
             setattr(self, key, value)
 
     def __str__(self):

--- a/rflib/intelhex.py
+++ b/rflib/intelhex.py
@@ -38,8 +38,8 @@
 '''
 from __future__ import division
 
+from builtins import bytes
 from builtins import str
-from builtins import chr
 from builtins import range
 from past.builtins import basestring
 from builtins import object
@@ -492,7 +492,7 @@ class IntelHex(object):
         # timeit shows that using hexstr.translate(table)
         # is faster than hexstr.upper():
         # 0.452ms vs. 0.652ms (translate vs. upper)
-        table = ''.join(chr(i).upper() for  i in range(256))
+        table = ''.join(bytes([i]).upper() for  i in range(256))
 
         # start address record if any
         if self.start_addr and write_start_addr:
@@ -710,7 +710,7 @@ class IntelHex(object):
                     if x is not None:
                         tofile.write(' %02X' % x)
                         if 32 <= x < 128:
-                            s.append(chr(x))
+                            s.append(bytes([x]))
                         else:
                             s.append('.')
                     else:
@@ -1012,7 +1012,7 @@ def _get_file_and_addr_range(s, _support_drive_letter=None):
         _support_drive_letter = (os.name == 'nt')
     drive = ''
     if _support_drive_letter:
-        if s[1:2] == ':' and s[0].upper() in ''.join([chr(i) for i in range(ord('A'), ord('Z')+1)]):
+        if s[1:2] == ':' and s[0].upper() in ''.join([bytes([i]) for i in range(ord('A'), ord('Z')+1)]):
             drive = s[:2]
             s = s[2:]
     parts = s.split(':')

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,8 @@ setup  (name             = 'rfcat',
         install_requires = [
                             'pyusb>=1.0.0',
                             'libusb>=1.0.21b2',
-                            'PySide2==5.12.0'
+                            'PySide2==5.12.0',
+                            'future>=0.17.1'
                            ],
         python_requires  = '>=2.7,<3.0.0'
         )


### PR DESCRIPTION
This PR is part of porting the Python 2 code to Python 3 without losing compatibility for Python 2.7 according to https://python-future.org/futurize.html.

**Note:** this PR is still work in progress!

### Description:

Stage 1 will apply fixes to modernize the Python 2 code without changing the effect of the code. The goal of this stage is to create most of the diff for the entire porting process, but without introducing any bugs.

Stage 2 will add a dependency on the `future` package. The goal for stage 2 is to make further mostly safe changes to the Python 2 code to use Python 3 style code that still runs on Python 2 with the help of the appropriate builtins and utilities in `future`.

In stage 3 we will be separating text from bytes manually by prefixing all the string literals with either `b` or `u` accordingly. To ensure that these type behave similarly on Python 2 as on Python 3, we will wrap byte-strings or text in the `bytes` and `str` types from `future`.

After running `futurize`, we start by testing compatibility on Python 3 and making further code changes until it's fully compatible with Python 3. The next step is to make manual tweaks to the code to re-enable Python 2 compatibility.

### Action Items:

- [x] Drop support for Python 2.6 and older (#33)
- [x] Stage 1 of `futurize` (_except for `vstruct/*`_)
- [x] Manually fix commented code and exception messages that aren't correctly ported by `futurize`.
- [x] Merge stage 1 changes into master (_most of the diff, minimal to no impact_) (#34)
- [x] Stage 2 of `futurize` (_except for `vstruct/*`_)
- [x] Merge stage 2 changes into master
- [ ] Stage 1 and 2 of `futurize` in `vstruct/*`
- [ ] Merge `futurize` changes in `vstruct/*` into master
- [ ] Separating text from bytes manually
- [ ] Test & make the code pass on Python 3
- [ ] Manually tweak to re-enable Python 2 compatibility
- [ ] Merge changes into master

### Additional Information:

This PR is part of fixing #15.