### PR TITLE
Revert bytes([]) to chr()

### DIFF
--- a/rflib/bits.py
+++ b/rflib/bits.py
@@ -3,7 +3,6 @@ from __future__ import division
 
 from builtins import hex
 from builtins import range
-from builtins import bytes
 from past.utils import old_div
 import struct
 
@@ -43,7 +42,7 @@ def strBitReverse(string):
     # convert back from MSB number to string
     out = []
     for x in range(len(string)):
-        out.append(bytes([rnum&0xff]))
+        out.append(chr(rnum&0xff))
         rnum >>= 8
     out.reverse()
     print(''.join(out).encode('hex'))
@@ -388,7 +387,7 @@ def bitSectString(string, startbit, endbit):
             mask = ~ ( (1<<diff) - 1 )
             byte &= mask
 
-        s += bytes([byte])
+        s += chr(byte)
     
     ent = old_div((min(entropy)+1.0), (max(entropy)+1))
     #print "entropy: %f" % ent
@@ -481,7 +480,7 @@ def invertBits(data):
     off = 0
 
     if ldata&1:
-        output.append( bytes([ ord( data[0] ) ^ 0xff]) )
+        output.append( chr( ord( data[0] ) ^ 0xff) )
         off = 1
 
     if ldata&2:
@@ -546,12 +545,12 @@ def diff_manchester_decode(data, align=False):
 
             last = (bit0 << 1) | bit1
         if (bidx & 1): 
-            out.append(bytes([obyte]))
+            out.append(chr(obyte))
             obyte = 0
 
     if not (bidx & 1):
         obyte << 4 # pad 0's on end
-        out.append(bytes([obyte]))
+        out.append(chr(obyte))
     return ''.join(out)
 
 
@@ -573,12 +572,12 @@ def biphase_mark_coding_encode(data):
             last = bit
         if bidx & 1:
             print("%d - write" % bidx)
-            out.append(bytes([obyte]))
+            out.append(chr(obyte))
         else:
             print("%d - skip" % bidx)
     if not (bidx & 1):
         print("%d - write" % bidx)
-        out.append(bytes([obyte]))
+        out.append(chr(obyte))
 
     return ''.join(out)
 
@@ -602,12 +601,12 @@ def manchester_decode(data, hilo=1):
 
             last = bit
         if (bidx & 1): 
-            out.append(bytes([obyte]))
+            out.append(chr(obyte))
             obyte = 0
 
     if not (bidx & 1):
         obyte << 4 # pad 0's on end
-        out.append(bytes([obyte]))
+        out.append(chr(obyte))
     return ''.join(out)
 
 def manchester_encode(data, hilo=1):

--- a/rflib/ccspecan.py
+++ b/rflib/ccspecan.py
@@ -24,7 +24,6 @@ from __future__ import division
 
 from future import standard_library
 standard_library.install_aliases()
-from builtins import bytes
 from builtins import range
 from past.utils import old_div
 import sys
@@ -415,7 +414,7 @@ class Window(QtWidgets.QWidget):
 
         # anything else is alphanumeric
         try:
-            key= bytes([event.key()]).upper()
+            key = chr(event.key()).upper()
             event.accept()
         except:
             print('Unknown key pressed: 0x%x' % event.key())

--- a/rflib/chipcon_nic.py
+++ b/rflib/chipcon_nic.py
@@ -4,7 +4,6 @@ from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
 
-from builtins import bytes
 from builtins import hex
 from builtins import range
 from builtins import object
@@ -443,14 +442,14 @@ class NICxx11(USBDongle):
             if 'suppress' the radio state (RX/TX/IDLE) is not modified
         '''
         if suppress:
-            self.poke(regaddr, bytes([value]))
+            self.poke(regaddr, chr(value))
             return
             
         marcstate = self.radiocfg.marcstate
         if marcstate != MARC_STATE_IDLE:
             self.strobeModeIDLE()
             
-        self.poke(regaddr, bytes([value]))
+        self.poke(regaddr, chr(value))
         
         self.strobeModeReturn(marcstate)
         #if (marcstate == MARC_STATE_RX):
@@ -1303,7 +1302,7 @@ class NICxx11(USBDongle):
         return self.send(APP_NIC, NIC_GET_AMP_MODE, "")
 
     def setPktAddr(self, addr):
-        return self.poke(ADDR, bytes([addr]))
+        return self.poke(ADDR, chr(addr))
 
     def getPktAddr(self):
         return self.peek(ADDR)
@@ -2035,9 +2034,9 @@ class FHSSNIC(NICxx11):
         t2ctl = (ord(self.peek(X_T2CTL)) & 0xfc)   | (tipidx)
         clkcon = (ord(self.peek(X_CLKCON)) & 0xc7) | (tickidx<<3)
         
-        self.poke(X_T2PR, bytes([PR]))
-        self.poke(X_T2CTL, bytes([t2ctl]))
-        self.poke(X_CLKCON, bytes([clkcon]))
+        self.poke(X_T2PR, chr(PR))
+        self.poke(X_T2CTL, chr(t2ctl))
+        self.poke(X_CLKCON, chr(clkcon))
 
     def _setMACmode(self, _mode):
         '''

--- a/rflib/chipcon_usb.py
+++ b/rflib/chipcon_usb.py
@@ -4,7 +4,6 @@ from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
 
-from builtins import bytes
 from builtins import str
 from builtins import hex
 from builtins import range
@@ -957,7 +956,7 @@ def unittest(self, mhz=24):
     print(repr(self.peek(0xf000, 400)))
 
     print("\nTesting USB poke/peek")
-    data = "".join([bytes([c]) for c in range(120)])
+    data = "".join([chr(c) for c in range(120)])
     where = 0xf300
     self.poke(where, data)
     ndata = self.peek(where, len(data))

--- a/rflib/intelhex.py
+++ b/rflib/intelhex.py
@@ -38,7 +38,6 @@
 '''
 from __future__ import division, print_function
 
-from builtins import bytes
 from builtins import str
 from builtins import range
 from past.builtins import basestring
@@ -490,7 +489,7 @@ class IntelHex(object):
         # timeit shows that using hexstr.translate(table)
         # is faster than hexstr.upper():
         # 0.452ms vs. 0.652ms (translate vs. upper)
-        table = ''.join(bytes([i]).upper() for  i in range(256))
+        table = ''.join(chr(i).upper() for  i in range(256))
 
         # start address record if any
         if self.start_addr and write_start_addr:
@@ -708,7 +707,7 @@ class IntelHex(object):
                     if x is not None:
                         tofile.write(' %02X' % x)
                         if 32 <= x < 128:
-                            s.append(bytes([x]))
+                            s.append(chr(x))
                         else:
                             s.append('.')
                     else:
@@ -1010,7 +1009,7 @@ def _get_file_and_addr_range(s, _support_drive_letter=None):
         _support_drive_letter = (os.name == 'nt')
     drive = ''
     if _support_drive_letter:
-        if s[1:2] == ':' and s[0].upper() in ''.join([bytes([i]) for i in range(ord('A'), ord('Z')+1)]):
+        if s[1:2] == ':' and s[0].upper() in ''.join([chr(i) for i in range(ord('A'), ord('Z')+1)]):
             drive = s[:2]
             s = s[2:]
     parts = s.split(':')


### PR DESCRIPTION
Revert `bytes([])` to `chr()` because it breaks the `d.setRFRegister()` function.

Unfortunately, I do not have time to resolve #44 and maintain compatibility with Python 3. 

This PR fixes #44.
