### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.revision
 firmware/.revision
 firmware/.serial
 firmware/*.asm
@@ -12,12 +13,36 @@ firmware/*.sym
 firmware/bins/*
 
 # Compiled python modules.
-*.pyc
+__pycache__/
+*.py[cod]
+*$py.class
 
-# Setuptools distribution folder.
-# /dist/
-/build/
+# Distribution and packaging.
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
 
-# Python egg metadata, regenerated from source files by setuptools.
-/*.egg-info
-/*.egg
+# Environments.
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/


### PR DESCRIPTION
Update `.gitignore` to include:
- The `.revision` file that gets created in the root of the project.
- Add exclude for common virtual environments used for Python development.
- Update byte-compiled / optimized / DLL files excludes.

Heavily based on this [Python.gitignore](https://github.com/github/gitignore/blob/master/Python.gitignore).