### PR TITLE
Fix exception handling for missing IPython

### DIFF
--- a/rflib/__init__.py
+++ b/rflib/__init__.py
@@ -62,17 +62,17 @@ class RfCat(FHSSNIC):
         window = rfspecan.Window(self, freq, fhigh, delta, 0)
         window.show()
         rfspecan._qt_app.exec_()
-        
+
     def _doSpecAn(self, centfreq, inc, count):
         '''
         store radio config and start sending spectrum analysis data
-        
+
         centfreq = Center Frequency
         '''
         if count>255:
             raise Exception("sorry, only 255 samples per pass... (count)")
 
-        spectrum = (count * inc) 
+        spectrum = (count * inc)
         halfspec = spectrum / 2.0
         basefreq = centfreq - halfspec
         if (count * inc) + basefreq > MAX_FREQ:
@@ -91,7 +91,7 @@ class RfCat(FHSSNIC):
         return freq, delta
 
     def _stopSpecAn(self):
-        ''' 
+        '''
         stop sending rfdata and return radio to original config
         '''
         self.send(APP_NIC, RFCAT_STOP_SPECAN, '')
@@ -106,10 +106,10 @@ class RfCat(FHSSNIC):
         buf = b''
 
         if len(fdtup)>1:
-            fd0i, fd0o = fdtup 
+            fd0i, fd0o = fdtup
         else:
-            fd0i, = fdtup 
-            fd0o, = fdtup 
+            fd0i, = fdtup
+            fd0o, = fdtup
 
         fdsock = False      # socket or fileio?
         if hasattr(fd0i, 'recv'):

--- a/rflib/__init__.py
+++ b/rflib/__init__.py
@@ -212,7 +212,7 @@ def interactive(idx=0, DongleClass=RfCat, intro=''):
     gbls = globals()
     lcls = locals()
 
-    shellfailed = False
+    shellexception = None
 
     try:
         from IPython.terminal.interactiveshell import TerminalInteractiveShell
@@ -223,9 +223,9 @@ def interactive(idx=0, DongleClass=RfCat, intro=''):
         print(intro)
         ipsh.mainloop()
     except ImportError as e:
-        shellfailed = True
+        shellexception = e
 
-    if shellfailed:
+    if shellexception:
         try:
             import IPython.Shell
             ipsh = IPython.Shell.IPShell(argv=[''], user_ns=lcls, user_global_ns=gbls)
@@ -233,9 +233,9 @@ def interactive(idx=0, DongleClass=RfCat, intro=''):
             ipsh.mainloop()
 
         except ImportError as e:
-            shellfailed = True
+            shellexception = e
 
-    if shellfailed:
+    if shellexception:
         try:
             from IPython.frontend.terminal.interactiveshell import TerminalInteractiveShell
             ipsh = TerminalInteractiveShell()
@@ -246,10 +246,10 @@ def interactive(idx=0, DongleClass=RfCat, intro=''):
             print(intro)
             ipsh.mainloop()
         except ImportError as e:
-            shellfailed = True
+            shellexception = e
 
-    if shellfailed:
-        print("falling back to straight Python... (%r)" % e)
+    if shellexception:
+        print("falling back to straight Python... (%r)" % shellexception)
         shell = code.InteractiveConsole(gbls)
         print(intro)
         shell.interact()


### PR DESCRIPTION
If IPython is missing, then rfcat crashes on startup:
```
Traceback (most recent call last):
  File "./rfcat", line 61, in <module>
    interactive(ifo.index, DongleClass=RfCat, intro=intro)
  File "/home/argilo/git/rfcat/rflib/__init__.py", line 252, in interactive
    print("falling back to straight Python... (%r)" % e)
UnboundLocalError: local variable 'e' referenced before assignment
```
This occurs because `e` is accessed outside an `except` block.

As noted in the Python documentation:

> When an exception has been assigned using `as target`, it is cleared at the end of the except clause. This means the exception must be assigned to a different name to be able to refer to it after the except clause.

I've done that here by assigning the exception to the `shellexception` variable, which makes the `shellfailed` variable unnecessary.