### PR TITLE
RFxmit(...) now successfully accepts strings with python3

### DIFF
--- a/rflib/chipcon_nic.py
+++ b/rflib/chipcon_nic.py
@@ -1124,7 +1124,7 @@ class NICxx11(USBDongle):
         waitlen = len(data)
         waitlen += repeat * (len(data) - offset)
         wait = USB_TX_WAIT * ((old_div(waitlen, RF_MAX_TX_BLOCK)) + 1)
-        self.send(APP_NIC, NIC_XMIT, b"%s" % struct.pack("<HHH",len(data),repeat,offset)+data, wait=wait)
+        self.send(APP_NIC, NIC_XMIT, "{}{}".format(struct.pack("<HHH",len(data),repeat,offset), data).encode("utf-8"), wait=wait)
 
     def RFxmitLong(self, data, doencoding=True):
         # encode, if necessary


### PR DESCRIPTION
Fix for the issue #86 

~~Sadly this would break support for python2, I think so.~~

~~Please tell me if this is a problem. There definitely is a way to enable this for both versions but since python2 is deprecated I didn't think about that.~~

Should now work with version 2.7 and 3.x
