### PR TITLE
Generalize revision.sh to POSIX shell, since it is free of bashisms.

### DIFF
--- a/revision.sh
+++ b/revision.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 git rev-list HEAD >/dev/null 2>&1
 if [ $? -eq 0 ]; then
     git rev-list HEAD --count | tee .revision


### PR DESCRIPTION
I noticed that the revision.sh script will work under a generic POSIX shell environment. This would help with packaging on some Linux distributions like NixOS that don't put `bash` in `/bin` as "`bash`" but as "`sh`" instead. Part of packaging rfcat for Nix/NixOS here: https://github.com/NixOS/nixpkgs/pull/114914