### PR TITLE
Work around a suspected SDCC bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ RfCat currently requires Python 2.7.  the only suspected incompatibilities with 
 ### Build requirements
 
 * Make
-* SDCC (no later than 3.5.0, newer versions do not work)
+* SDCC
 
 ## DEVELOPMENT
 
@@ -178,10 +178,10 @@ You will also need to install the build requirements of python-usb, libusb-1.0.0
 * python-usb
 * libusb-1.0.0
 * make
-* sdcc  (no later than version 3.5.0, newer versions will not work)
+* sdcc
 
 ```
-sudo apt install python-usb libusb-1.0.0 make sdcc=3.5.0
+sudo apt install python-usb libusb-1.0.0 make sdcc
 ```
 
 For sdcc and its dependency, sdcc-libraries, you may need to download it from a earlier release's repository if you are on a newer version of Debian or Ubuntu  such as:

--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -4,17 +4,11 @@ BOOTLOADER_SIZE = 0x1400
 LDFLAGS_FLASH = --code-loc $(BOOTLOADER_SIZE)
 USB_DEVICE_SERIAL_NUMBER="`./new_serial.py`"
 
-SDCCVEROK=$(shell expr `sdcc --version|grep SDCC|cut -d' ' -f 4` \<= 3.5.0)
-
 CC=sdcc
 RFLIB_VERSION=`../revision.sh`
 CFLAGS=-Iinclude -DBUILD_VERSION=$(RFLIB_VERSION)
 CFLAGSold=--no-pack-iram $(CF)
 LFLAGS=--xram-loc 0xF000 
-
-ifeq "$(SDCCVEROK)" "0"
-    CC=FUCKNO_use_SDCC_3.5.0_instead
-endif
 
 apps2531 = global.rel
 apps1111 = cc1111rf.rel global.rel cc1111_aes.rel

--- a/firmware/include/chipcon_usb.h
+++ b/firmware/include/chipcon_usb.h
@@ -271,7 +271,7 @@ typedef struct {
     u8*  INbuf;
     u16  INbytesleft;
     u8*  OUTbuf;
-    u16  OUTlen;
+    volatile u16  OUTlen;
     u8   OUTapp;
     u8   OUTcmd;
     u16  OUTbytesleft;


### PR DESCRIPTION
Fixes #121.

SDCC >= 3.8.0 appears to have a bug (https://sourceforge.net/p/sdcc/bugs/3381/) which causes incorrect compilation of the `ep5.OUTlen += len;` line in chipcon_usb.c, corrupting the value of `ep5.OUTlen`. To work around the problem, we can mark the `OUTlen` field as volatile to prevent optimizations from being applied to it.

After this change, I can build a working firmware using SDCC 3.8.0, which ships with Ubuntu 20.04.