### PR TITLE
Fixes bug caused by future import statement not being at the top

### DIFF
--- a/rfcat_server
+++ b/rfcat_server
@@ -1,5 +1,6 @@
 #!/usr/bin/python
 
+from __future__ import print_function
 import re
 import os
 import sys
@@ -8,7 +9,6 @@ import socket
 import threading
 
 from rflib import *
-from __future__ import print_function
 
 DATA_START_IDX = 4      # without the app/cmd/len bytes, the data starts at byte 4
 


### PR DESCRIPTION
* In Python3 the statement that imports the print function from future will fail if not at the top of the file:
    from __future__ import print_function
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
SyntaxError: from __future__ imports must occur at the beginning of the file

This small PR addresses that bug by moving it to the top.