### PR TITLE
Re-bind shellexception and set STYPE_CODE_INTERACT after IPYTHON811P change

### DIFF
--- a/rflib/__init__.py
+++ b/rflib/__init__.py
@@ -256,9 +256,10 @@ def interact(lcls, gbls, intro=""):
 
                     print(intro)
                 except ImportError as e:
+                    shellexception = e
                     print(e)
                     shell = code.InteractiveConsole(gbls)
-                    shelltype = STYPE_IPYTHON
+                    shelltype = STYPE_CODE_INTERACT
                     print(intro)
 
     if shelltype == STYPE_IPYTHON811P:


### PR DESCRIPTION
See 6e17f4e2f19ff2474b455ffec98a58465c85130d

Before:

```
No module named 'IPython'
UnboundLocalError: cannot access local variable 'ipsh' where it is not associated with a value
```

After:

```
No module named 'IPython'
falling back to straight Python... (ModuleNotFoundError("No module named 'IPython'")) (InteractiveConsole)
>>>
```

Cheers mate