### PR TITLE
Fix bug in setMdmChanBW()

### DIFF
--- a/rflib/chipcon_nic.py
+++ b/rflib/chipcon_nic.py
@@ -763,7 +763,7 @@ class NICxx11(USBDongle):
         if chanbw_e is None:
             raise Exception("ChanBW does not translate into acceptable parameters.  Should you be changing this?")
 
-        bw = 1000.0*mhz / (8.0*(4+chanbw_m) * pow(2,chanbw_e))
+        bw = 1000000.0*mhz / (8.0*(4+chanbw_m) * pow(2,chanbw_e))
         #print "chanbw_e: %x   chanbw_m: %x   chanbw: %f kHz" % (e, m, bw)
 
         radiocfg.mdmcfg4 &= ~(MDMCFG4_CHANBW_E | MDMCFG4_CHANBW_M)


### PR DESCRIPTION
With the original 

bw = 1000.0 * mhz / (8.0 *( 4+chanbw_m) * pow(2,chanbw_e))

chanbw_m and chanbw_e both have a range from 0 to 3 inclusive, using those values( chanbw_m and chanbw_e both at 0, both at 1, etc, others will fall inbetween the max and min) you would get a bw of the following (division, smaller numbers make the denominator smaller).

750.0
300.0
125.0
53.57142857142857

Given these bw values, the subsequent if statements will never be true:

        if bw > 102e3:
            self.setRFRegister(FREND1, 0xb6)
        else:
            self.setRFRegister(FREND1, 0x56)

        if bw > 325e3:
            self.setRFRegister(TEST2, 0x88)
            self.setRFRegister(TEST1, 0x31)
        else:
            self.setRFRegister(TEST2, 0x81)
            self.setRFRegister(TEST1, 0x35)


Additionally this same equation with a different (correct) multiplier for mhz is used in getMdmChanBW yields the following bw values which would result in the if statements potentially being true.
750000.0
300000.0
125000.0
53571.42857142857