### PR TITLE
Fixes for Markdown and small case errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The goals of the project are to reduce the time for security researchers to crea
 
 ## REQUIREMENTS
 
-RfCat currently requires Python 2.7.  the only suspected incompatibilities with Python 3.x are minimal, mostly print("stuff") versus print "stuff" and other str/bytes issues.
+RfCat currently requires Python 2.7.  the only suspected incompatibilities with Python 3.x are minimal, mostly `print("stuff")` versus `print "stuff"` and other str/bytes issues.
 
 ### Other requirements
 
@@ -33,8 +33,8 @@ RfCat currently requires Python 2.7.  the only suspected incompatibilities with 
 * libusb - should be able to work with either 1.x or 0.1 versions.  please let us know if you run into issues.
 * pyreadline (especially for Windows)
 * PySide2 (for Spectrum Analyzer GUI):  (Ubuntu 18.10+: python-pyside2)
-    PySide2 is no longer installed automatically, due to support concerns for RPi platforms.  You can install it (if available for your platform) using pip:
-    $ sudo pip install PySide2  
+    PySide2 is no longer installed automatically, due to support concerns for RPi platforms.  You can install it (if available for your platform) using `pip`:
+    `$ sudo pip install PySide2`
 
 ### Build requirements
 
@@ -43,14 +43,14 @@ RfCat currently requires Python 2.7.  the only suspected incompatibilities with 
 
 ## DEVELOPMENT
 
-New development efforts should copy the "application.c" file to "appWhateverMyToolIs.c" and attempt to avoid making changes to other files in the repo if at all possible.  that is only a recommendation, because future bug-fixes in other libraries/headers will go much more smoothely for you.
+New development efforts should copy the `application.c` file to `appWhateverMyToolIs.c` and attempt to avoid making changes to other files in the repo if at all possible.  that is only a recommendation, because future bug-fixes in other libraries/headers will go much more smoothely for you.
 
 ### Gotchas
 
-A couple [gotchas](https://en.wikipedia.org/wiki/Gotcha_(programming)) to keep in mind while developing for the cc1111
+A couple [gotchas](https://en.wikipedia.org/wiki/Gotcha_(programming)) to keep in mind while developing for the CC1111
 
 * The memory model includes both "RAM" and "XDATA" concepts, and standard RAM variables and XDATA variables have different assembly instructions that are used to access them.  this means that you may find oddities when using a function written for XDATA on a standard RAM variable, and vice-versa.
-* Variables should be defined in a single .c file, and then "externs" declared in a .h file that can be included in other modules.  this is pretty standard for c programs, but both this and the previous point caused me difficulties at some points, and i found myself unsure what was causing my troubles.
+* Variables should be defined in a single `.c` file, and then "externs" declared in a `.h` file that can be included in other modules.  this is pretty standard for C programs, but both this and the previous point caused me difficulties at some points, and i found myself unsure what was causing my troubles.
 * RAM memory is not cheap.  use it sparingly.
 * You need to set the radio into IDLE mode before reconfiguring it
 * You need to set the radio into TX mode *before* writing to the RFD register (firmware) as it is a 1-byte FIFO.
@@ -64,7 +64,7 @@ First things first. Using rfcat requires that you either use the python client i
 
 ### allowing non-root dongle access
 
-```
+```sh
 sudo cp etc/udev/rules.d/20-rfcat.rules /etc/udev/rules.d
 sudo udevadm control --reload-rules
 ```
@@ -180,7 +180,7 @@ You will also need to install the build requirements of python-usb, libusb-1.0.0
 * make
 * sdcc
 
-```
+```sh
 sudo apt install python-usb libusb-1.0.0 make sdcc
 ```
 
@@ -189,9 +189,9 @@ For sdcc and its dependency, sdcc-libraries, you may need to download it from a 
 * https://packages.debian.org/stretch/sdcc
 
 Next, your user must have read/write access to the dongle when it shows up to the operating system.  
-For most Linux distros, this means you have to be a member of the "dialout" group.
+For most Linux distros, this means you have to be a member of the `dialout` group.
 
-```
+```sh
 usermod -a -G sudo $USER
 su - $USER
 ```
@@ -199,7 +199,7 @@ su - $USER
 You will also need permanent symlinks to the USB serial devices that will communicate with the CHRONOS, DONSDONGLE or YARDSTICKONE
 bootloader when required. If you haven't done this step already (see above), then run:
 
-```
+```sh
 sudo cp etc/udev/rules.d/20-rfcat.rules /etc/udev/rules.d
 sudo udevadm control --reload-rules
 ```
@@ -210,7 +210,7 @@ To prepare your dongle for the first time, you'll need to hook up your debugger 
 
 Intended development model is using a [GoodFET](http://goodfet.sf.net) although one of our developers uses the chipcon debugger from Texas Instruments.
 
-```
+```sh
 cd rfcat/firmware/
 make testgoodfet
 ```
@@ -244,16 +244,24 @@ and do:
 
 (install `rfcat_bootloader` from the CC-Bootloader subdirectory to somewhere on your execution path)
 
-`cd firmware`
+```sh
+cd firmware
+```
 
 for EMK/DONSDONGLE:
-  `make installdonsbootloader`
+```sh
+make installdonsbootloader
+```
 
 for CHRONOS:
-  `make installchronosbootloader`
+```sh
+make installchronosbootloader
+```
 
 for YARDSTICKONE:
-  `make installys1bootloader`
+```sh
+make installys1bootloader
+```
 
 now unplug the debugger and plug in your USB dongle.
 
@@ -261,23 +269,31 @@ If you have just installed the bootloader, the dongle should be in bootloader mo
 
 ### Steps for firmware updates via USB port
 
-If you are re-flashing a dongle that is already running rfcat firmware, such as a YarstickOne, the Makefile targets will force it into bootloader
+If you are re-flashing a dongle that is already running rfcat firmware, such as a YarstickOne, the `Makefile` targets will force it into bootloader
 mode for you, but you can manually put it into bootloader mode either by holding down the EMK/DONS button as you plug 
 it into USB (on the CHRONOS or YARDSTICKONE jumper P2_2/DC to GROUND), or by issuing the command `d.bootloader()` to rfcat in interactive 
 mode (`rfcat -r`), or by issuing the command `rfcat --bootloader --force` from the command line.
 
 Once you have a solid LED, or if you're running an rfcat dongle, you can do the following:
 
-`cd firmware`
+```sh
+cd firmware
+```
 
 for EMK/DONSDONGLE:
-* `make installRfCatDonsDongleCCBootloader`
+```sh
+make installRfCatDonsDongleCCBootloader
+```
 
 for CHRONOS:
-* `make installRfCatChronosDongleCCBootloader`
+```sh
+make installRfCatChronosDongleCCBootloader
+```
 
 for YARDSTICKONE:
-* `make installRfCatYS1CCBootloader`
+```sh
+make installRfCatYS1CCBootloader
+```
 
 The new version will be installed, and bootloader exited.
 
@@ -293,19 +309,19 @@ Install rfcat onto your system.  on most linux systems, this will place `rfcat` 
 ### Installation
 
 * cd into the rfcat directory (created by unpacking the tarball or by git clone)
-* sudo python setup.py install
+* `sudo python setup.py install`
 * I highly recommend installing `ipython`
   * For deb/ubuntu folk: `apt-get install ipython`
 
 #### Installation with pip
 * cd into the rfcat directory (created by unpacking the tarball or by git clone)
-* ```pip install -e .```  (installs in editable mode and runs from the unpacked or checked out location)
+* `pip install -e .`  (installs in editable mode and runs from the unpacked or checked out location)
 
 ## Using rfcat
 
 If you have configured your system to allow non-root use:
 
-* type "rfcat -r"   (if your system is not configured to allow non-root use, prepend "sudo" or you must run as root)
+* type `rfcat -r`   (if your system is not configured to allow non-root use, prepend `sudo` or you must run as root)
     you should have now entered an interactive python shell, where tab-completion and other aids should make a very powerful experience
     i love the raw-byte handling and introspection of it all.
 
@@ -321,15 +337,16 @@ If you have configured your system to allow non-root use:
     * d.setEnableMdmFEC(True)   # enables the convolutional Forward Error Correction built into the radio
 
 
-while the toolset was created to make communicating with <ghz much easier, you will find the cc1111 manual from ti a great value.  the better you understand the radio, the better your experience will be.
-play with the radio settings, but i recommend playing in small amounts and watch for the effects.  several things in the radio configuration settings are mandatory to get right in order to receive or transmit anything (one of those odd requirements is the TEST2/1/0 registers!)
+while the toolset was created to make communicating with sub-GHz much easier, you will find the CC1111 manual from TI a great value.  the better you understand the radio, the better your experience will be.
+play with the radio settings, but i recommend playing in small amounts and watch for the effects.  several things in the radio configuration settings are mandatory to get right in order to receive or transmit anything (one of those odd requirements is the `TEST2/1/0` registers!)
 
 If you watched any of my talks on rfcat, you will likely remember that you need to put the radio in **IDLE state** before configuring. (I said it three times, in a row, in different inflections).
 
 However, you will find that I've done that for you in the client for most things.  The only time you need to do this yourself are:
+
     * If you are doing the changes in firmware
-    * If you are using the "d.poke()" functionality
-        * if you use "d.setRFRegister()", this is handled for you
+    * If you are using the `d.poke()` functionality
+        * if you use `d.setRFRegister()`, this is handled for you
         * `use d.setRFRegister()`
 
 ## External Projects

--- a/README.md
+++ b/README.md
@@ -344,10 +344,10 @@ If you watched any of my talks on rfcat, you will likely remember that you need 
 
 However, you will find that I've done that for you in the client for most things.  The only time you need to do this yourself are:
 
-    * If you are doing the changes in firmware
-    * If you are using the `d.poke()` functionality
-        * if you use `d.setRFRegister()`, this is handled for you
-        * `use d.setRFRegister()`
+* If you are doing the changes in firmware
+* If you are using the `d.poke()` functionality
+    * if you use `d.setRFRegister()`, this is handled for you
+    * `use d.setRFRegister()`
 
 ## External Projects
 [ZWave Attack](https://www.initbrain.fr/security/2016/z-attack/):  [https://github.com/initbrain/Z-Attack](https://github.com/initbrain/Z-Attack)


### PR DESCRIPTION
These fixes improve readability of the README file. Mostly added syntax highlighting by changing `` to ```sh...```. Case errors relate to chip and register names.